### PR TITLE
fix: resolve default branch dynamically for commits check

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1088,9 +1088,9 @@ enabled with the `-c` flag:
 ```
 
 The `-c` flag validates commits between HEAD and the upstream tracking branch
-(or `origin/main` for new branches). Merge commits are skipped. Each commit
-message must match the format `type[(scope)][!]: description`, where the
-description must not start with uppercase.
+(or the origin's default branch for new branches). Merge commits are skipped.
+Each commit message must match the format `type[(scope)][!]: description`, where
+the description must not start with uppercase.
 
 Both flags can be combined: `./pok -g -c`.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -86,9 +86,9 @@ enabled with the `-c` flag:
 ```
 
 The `-c` flag validates commits between HEAD and the upstream tracking branch
-(or `origin/main` for new branches). Merge commits are skipped. Each commit
-message must match the format `type[(scope)][!]: description`, where the
-description must not start with uppercase.
+(or the origin's default branch for new branches). Merge commits are skipped.
+Each commit message must match the format `type[(scope)][!]: description`, where
+the description must not start with uppercase.
 
 ---
 

--- a/pk/builtins.go
+++ b/pk/builtins.go
@@ -220,10 +220,12 @@ var commitsCheckTask = &Task{
 // resolveCommitRange determines the git log range for commit validation.
 // Returns empty string if there are no commits to validate.
 func resolveCommitRange(ctx context.Context) (string, error) {
+	gitRoot := findGitRoot()
+
 	// Try upstream tracking branch first.
 	//nolint:gosec // Arguments are fixed git commands, not user-supplied.
 	cmd := exec.CommandContext(ctx, "git", "log", "--oneline", "@{push}..HEAD")
-	cmd.Dir = findGitRoot()
+	cmd.Dir = gitRoot
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out
@@ -234,21 +236,43 @@ func resolveCommitRange(ctx context.Context) (string, error) {
 		return "@{push}..HEAD", nil
 	}
 
-	// Fall back to origin/main.
-	//nolint:gosec // Arguments are fixed git commands, not user-supplied.
-	cmd = exec.CommandContext(ctx, "git", "log", "--oneline", "origin/main..HEAD")
-	cmd.Dir = findGitRoot()
+	// Fall back to origin's default branch.
+	defaultBranch := resolveDefaultBranch(ctx, gitRoot)
+	if defaultBranch == "" {
+		// Cannot determine default branch (e.g. shallow clone in CI) — silent no-op.
+		return "", nil
+	}
+
+	ref := "origin/" + defaultBranch + "..HEAD"
+	//nolint:gosec // ref is constructed from git output, not user input.
+	cmd = exec.CommandContext(ctx, "git", "log", "--oneline", ref)
+	cmd.Dir = gitRoot
 	out.Reset()
 	cmd.Stdout = &out
 	cmd.Stderr = &out
-	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("git log origin/main..HEAD: %w\n%s", err, out.String())
+	// Ref may not be available (e.g. shallow clone in CI) — treat as no-op.
+	if cmd.Run() == nil && strings.TrimSpace(out.String()) != "" {
+		return ref, nil
 	}
+	return "", nil
+}
 
-	if strings.TrimSpace(out.String()) == "" {
-		return "", nil // Zero commits in range.
+// resolveDefaultBranch returns the default branch name of the origin remote.
+// Returns empty string if it cannot be determined.
+func resolveDefaultBranch(ctx context.Context, gitRoot string) string {
+	// Use git symbolic-ref to find what origin/HEAD points to.
+	//nolint:gosec // Arguments are fixed git commands, not user-supplied.
+	cmd := exec.CommandContext(ctx, "git", "symbolic-ref", "refs/remotes/origin/HEAD")
+	cmd.Dir = gitRoot
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return ""
 	}
-	return "origin/main..HEAD", nil
+	// Output is e.g. "refs/remotes/origin/main\n".
+	ref := strings.TrimSpace(out.String())
+	return strings.TrimPrefix(ref, "refs/remotes/origin/")
 }
 
 // selfUpdateFlags defines flags for the self-update task.


### PR DESCRIPTION
## Why

The `-c` flag's commit range resolution hardcoded `origin/main`, which fails in
repos using a different default branch and in CI shallow clones where the ref
isn't available.

## What

- Use `git symbolic-ref refs/remotes/origin/HEAD` to detect the default branch
  dynamically
- Treat unavailable refs as a silent no-op instead of erroring (fixes CI
  failures with shallow clones)
- Update docs to say "origin's default branch" instead of "origin/main"

## Notes

Fixes the CI failure in the release-please PR where `origin/main` wasn't
available in the shallow checkout.