### PR TITLE
docs: fix inaccuracies and sync with codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,9 @@ Pocket is built around two primitives: **tasks** and **tools**.
 composed into execution trees using `Serial` and `Parallel`.
 
 **Tools** are the dependencies tasks need to run. Instead of assuming
-`golangci-lint` is installed, you declare it as a tool:
-
-Pocket downloads, versions, and caches tools in `.pocket/tools/`, ensuring
-reproducible builds across machines and CI environments. Everyone gets the exact
-same version.
+`golangci-lint` is installed, you declare it as a tool. Pocket downloads,
+versions, and caches tools in `.pocket/tools/`, ensuring reproducible builds
+across machines and CI environments. Everyone gets the exact same version.
 
 > [!TIP]
 >
@@ -120,7 +118,7 @@ workflows:
 ```go
 var Config = &pk.Config{
     Auto: pk.Serial(
-        Format,                   // first run tests
+        Format,                   // first format
         pk.Parallel(Lint, Test),  // then run concurrently
         Build,                    // finally build
     ),
@@ -170,9 +168,9 @@ bypass deduplication when needed.
 
 ### Shim Scoping
 
-Pocket generates shims in each detected module directory (`pk.Detect`) and each
-path defined with `pk.WithPath`. The root shim runs everything, while subfolder
-shims only run tasks scoped to that path:
+Pocket generates shims in each detected module directory (`pk.WithDetect`) and
+each path defined with `pk.WithPath`. The root shim runs everything, while
+subfolder shims only run tasks scoped to that path:
 
 ```bash
 ./pok                       # runs all tasks across all paths
@@ -204,7 +202,7 @@ Pocket provides a built-in `plan` command to visualize your execution tree:
 
 Tasks can access the full execution plan at runtime via
 `pk.PlanFromContext(ctx)`. This enables powerful workflows like **automatic CI
-workflow generation** instead of manually syncing your CI configuration with
+workflow generation** -- instead of manually syncing your CI configuration with
 your tasks, let Pocket generate it.
 
 Here's an example using the

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -269,13 +269,15 @@ project controls tool versions, not Pocket.
 
 ### Go Tools
 
-Use `pk.InstallGo` for Go-based tools:
+Use `golang.Install` for Go-based tools:
 
 ```go
+import "github.com/fredrikaverpil/pocket/tools/golang"
+
 var installLint = &pk.Task{
     Name:   "install:golangci-lint",
     Usage:  "install linter",
-    Body:   pk.InstallGo("github.com/golangci/golangci-lint/cmd/golangci-lint", "v1.64.8"),
+    Body:   golang.Install("github.com/golangci/golangci-lint/v2/cmd/golangci-lint", "v2.1.6"),
     Hidden: true,
     Global: true,
 }
@@ -432,8 +434,8 @@ workflow generation.
 > [!NOTE]
 >
 > Tests run without coverage by default to avoid conflicts when testing multiple
-> Python versions. Use `python.WithTestCoverage()` to enable coverage for one
-> version.
+> Python versions. Use `python.TestFlags{Coverage: true}` to enable coverage for
+> one version.
 
 #### Venv Location
 
@@ -1126,7 +1128,7 @@ type Plan struct {
 }
 
 // Public methods
-func (p *Plan) Tasks() []*Task           // All tasks in the plan
+func (p *Plan) Tasks() []TaskInfo        // All tasks in the plan
 func (p *Plan) ShimConfig() *ShimConfig  // Resolved shim configuration
 ```
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -377,15 +377,17 @@ Use runtime's `Run()` function directly.
 
 ### Go Tools
 
+Import: `"github.com/fredrikaverpil/pocket/tools/golang"`
+
 ```go
-func InstallGo(pkg, version string) Runnable
+func Install(pkg, version string) pk.Runnable
 ```
 
-Installs a Go package to `.pocket/tools/go/<pkg>/<version>/bin/` and symlinks to
+Installs a Go package to `.pocket/tools/go/<pkg>/<version>/` and symlinks to
 `.pocket/bin/`. Uses **Symlink pattern**.
 
 ```go
-pk.InstallGo("github.com/golangci/golangci-lint/cmd/golangci-lint", "v1.64.8")
+golang.Install("github.com/golangci/golangci-lint/v2/cmd/golangci-lint", "v2.1.6")
 ```
 
 ### Runtime-Dependent Tools
@@ -414,14 +416,14 @@ Import: `"github.com/fredrikaverpil/pocket/pk/download"`
 func Download(url string, opts ...Opt) pk.Runnable
 ```
 
-| Option             | Description                                              |
-| :----------------- | :------------------------------------------------------- |
-| `WithDestDir`      | Destination directory for extraction                     |
-| `WithFormat`       | Archive format: `"tar.gz"`, `"tar"`, `"zip"`, `"gz"`, `` |
-| `WithExtract`      | Add extraction options                                   |
-| `WithSymlink`      | Create symlink in `.pocket/bin/`                         |
-| `WithSkipIfExists` | Skip download if file exists                             |
-| `WithOutputName`   | Output filename for `"gz"` format (required for gz)      |
+| Option             | Description                                                      |
+| :----------------- | :--------------------------------------------------------------- |
+| `WithDestDir`      | Destination directory for extraction                             |
+| `WithFormat`       | Archive format: `"tar.gz"`, `"tar"`, `"zip"`, `"gz"`, `""` (raw) |
+| `WithExtract`      | Add extraction options                                           |
+| `WithSymlink`      | Create symlink in `.pocket/bin/`                                 |
+| `WithSkipIfExists` | Skip download if file exists                                     |
+| `WithOutputName`   | Output filename for `"gz"` format (required for gz)              |
 
 ```go
 import "github.com/fredrikaverpil/pocket/pk/download"

--- a/tools/README.md
+++ b/tools/README.md
@@ -175,9 +175,9 @@ bypass deduplication when needed.
 
 ### Shim Scoping
 
-Pocket generates shims in each detected module directory (`pk.Detect`) and each
-path defined with `pk.WithPath`. The root shim runs everything, while subfolder
-shims only run tasks scoped to that path:
+Pocket generates shims in each detected module directory (`pk.WithDetect`) and
+each path defined with `pk.WithPath`. The root shim runs everything, while
+subfolder shims only run tasks scoped to that path:
 
 ```bash
 ./pok                       # runs all tasks across all paths

--- a/tools/docs/guide.md
+++ b/tools/docs/guide.md
@@ -269,13 +269,15 @@ project controls tool versions, not Pocket.
 
 ### Go Tools
 
-Use `pk.InstallGo` for Go-based tools:
+Use `golang.Install` for Go-based tools:
 
 ```go
+import "github.com/fredrikaverpil/pocket/tools/golang"
+
 var installLint = &pk.Task{
     Name:   "install:golangci-lint",
     Usage:  "install linter",
-    Body:   pk.InstallGo("github.com/golangci/golangci-lint/cmd/golangci-lint", "v1.64.8"),
+    Body:   golang.Install("github.com/golangci/golangci-lint/v2/cmd/golangci-lint", "v2.1.6"),
     Hidden: true,
     Global: true,
 }
@@ -432,8 +434,8 @@ workflow generation.
 > [!NOTE]
 >
 > Tests run without coverage by default to avoid conflicts when testing multiple
-> Python versions. Use `python.WithTestCoverage()` to enable coverage for one
-> version.
+> Python versions. Use `python.TestFlags{Coverage: true}` to enable coverage for
+> one version.
 
 #### Venv Location
 
@@ -1088,9 +1090,9 @@ enabled with the `-c` flag:
 ```
 
 The `-c` flag validates commits between HEAD and the upstream tracking branch
-(or `origin/main` for new branches). Merge commits are skipped. Each commit
-message must match the format `type[(scope)][!]: description`, where the
-description must not start with uppercase.
+(or the origin's default branch for new branches). Merge commits are skipped.
+Each commit message must match the format `type[(scope)][!]: description`, where
+the description must not start with uppercase.
 
 Both flags can be combined: `./pok -g -c`.
 
@@ -1126,7 +1128,7 @@ type Plan struct {
 }
 
 // Public methods
-func (p *Plan) Tasks() []*Task           // All tasks in the plan
+func (p *Plan) Tasks() []TaskInfo        // All tasks in the plan
 func (p *Plan) ShimConfig() *ShimConfig  // Resolved shim configuration
 ```
 

--- a/tools/docs/reference.md
+++ b/tools/docs/reference.md
@@ -86,9 +86,9 @@ enabled with the `-c` flag:
 ```
 
 The `-c` flag validates commits between HEAD and the upstream tracking branch
-(or `origin/main` for new branches). Merge commits are skipped. Each commit
-message must match the format `type[(scope)][!]: description`, where the
-description must not start with uppercase.
+(or the origin's default branch for new branches). Merge commits are skipped.
+Each commit message must match the format `type[(scope)][!]: description`, where
+the description must not start with uppercase.
 
 ---
 
@@ -377,15 +377,17 @@ Use runtime's `Run()` function directly.
 
 ### Go Tools
 
+Import: `"github.com/fredrikaverpil/pocket/tools/golang"`
+
 ```go
-func InstallGo(pkg, version string) Runnable
+func Install(pkg, version string) pk.Runnable
 ```
 
-Installs a Go package to `.pocket/tools/go/<pkg>/<version>/bin/` and symlinks to
+Installs a Go package to `.pocket/tools/go/<pkg>/<version>/` and symlinks to
 `.pocket/bin/`. Uses **Symlink pattern**.
 
 ```go
-pk.InstallGo("github.com/golangci/golangci-lint/cmd/golangci-lint", "v1.64.8")
+golang.Install("github.com/golangci/golangci-lint/v2/cmd/golangci-lint", "v2.1.6")
 ```
 
 ### Runtime-Dependent Tools
@@ -414,14 +416,14 @@ Import: `"github.com/fredrikaverpil/pocket/pk/download"`
 func Download(url string, opts ...Opt) pk.Runnable
 ```
 
-| Option             | Description                                              |
-| :----------------- | :------------------------------------------------------- |
-| `WithDestDir`      | Destination directory for extraction                     |
-| `WithFormat`       | Archive format: `"tar.gz"`, `"tar"`, `"zip"`, `"gz"`, `` |
-| `WithExtract`      | Add extraction options                                   |
-| `WithSymlink`      | Create symlink in `.pocket/bin/`                         |
-| `WithSkipIfExists` | Skip download if file exists                             |
-| `WithOutputName`   | Output filename for `"gz"` format (required for gz)      |
+| Option             | Description                                                      |
+| :----------------- | :--------------------------------------------------------------- |
+| `WithDestDir`      | Destination directory for extraction                             |
+| `WithFormat`       | Archive format: `"tar.gz"`, `"tar"`, `"zip"`, `"gz"`, `""` (raw) |
+| `WithExtract`      | Add extraction options                                           |
+| `WithSymlink`      | Create symlink in `.pocket/bin/`                                 |
+| `WithSkipIfExists` | Skip download if file exists                                     |
+| `WithOutputName`   | Output filename for `"gz"` format (required for gz)              |
 
 ```go
 import "github.com/fredrikaverpil/pocket/pk/download"


### PR DESCRIPTION
## Why?

Several documentation files had inaccuracies that did not reflect the actual
codebase API, including a non-existent function, wrong return types, incorrect
comments, and grammatical issues.

## What?

- Fix `pk.InstallGo` (non-existent) to `golang.Install` from `tools/golang` package in guide and reference
- Fix `pk.Detect` (non-existent) to `pk.WithDetect` in README and tools/README
- Fix `Plan.Tasks()` return type from `[]*Task` to `[]TaskInfo` in guide
- Fix `python.WithTestCoverage()` (non-existent) to `python.TestFlags{Coverage: true}` in guide
- Fix misleading comment `// first run tests` to `// first format` in README
- Fix dangling colon after "you declare it as a tool:" with no example following in README
- Clarify empty format string in reference download options table
- Fix run-on sentence in README introspection section
- Sync `tools/docs/` and `tools/README.md` copies with their source files