### PR TITLE
ci(renovate): enable gomodTidy post-update option

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,9 @@
   "extends": [
     "config:recommended"
   ],
+  "postUpdateOptions": [
+    "gomodTidy"
+  ],
   "packageRules": [
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
## Why?

When Renovate bumps Go dependencies, the resulting `go.mod`/`go.sum` may
need a `go mod tidy` to stay consistent. Without this, Renovate PRs can
fail CI checks or require manual tidying.

## What?

- Add `gomodTidy` to `postUpdateOptions` in `renovate.json`

## Notes

- Docs: https://docs.renovatebot.com/configuration-options/#postupdateoptions