### PR TITLE
fix: tighten conventional commit validation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,10 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           requireScope: false
-          subjectPattern: ^(?![A-Z]).+$
+          subjectPattern: ^(?![A-Z]).{1,64}$
+          subjectPatternError: |
+            The subject must not start with an uppercase letter and must be at most 64 characters.
+            (Total limit is 72 characters including the type and scope prefix.)
           scopes: |
             .+
           types: |
@@ -31,12 +34,10 @@ jobs:
             docs
             feat
             fix
-            merge
             perf
             refactor
             revert
             style
             test
-            wip
           ignoreLabels: |
             autorelease: pending

--- a/pk/conventional_commits.go
+++ b/pk/conventional_commits.go
@@ -7,11 +7,14 @@ import (
 	"sync"
 )
 
+// MaxSubjectLength is the maximum allowed length for a commit subject line.
+const MaxSubjectLength = 72
+
 // ConventionalCommitTypes is the set of allowed conventional commit types.
 // Used by the -c builtin and the pr.yml workflow template.
 var ConventionalCommitTypes = []string{
 	"build", "chore", "ci", "docs", "feat", "fix",
-	"merge", "perf", "refactor", "revert", "style", "test", "wip",
+	"perf", "refactor", "revert", "style", "test",
 }
 
 var (
@@ -22,7 +25,7 @@ var (
 func conventionalCommitRegex() *regexp.Regexp {
 	commitRegexOnce.Do(func() {
 		types := strings.Join(ConventionalCommitTypes, "|")
-		pattern := fmt.Sprintf(`^(%s)(\(.+\))?!?: (?:[^A-Z]).+$`, types)
+		pattern := fmt.Sprintf(`^(%s)(\([^)]+\))?!?: (?:[^A-Z]).+$`, types)
 		commitRegex = regexp.MustCompile(pattern)
 	})
 	return commitRegex
@@ -42,6 +45,10 @@ func ValidateCommitMessage(msg string) error {
 	// Skip merge commits.
 	if strings.HasPrefix(firstLine, "Merge ") {
 		return nil
+	}
+
+	if len(firstLine) > MaxSubjectLength {
+		return fmt.Errorf("subject exceeds %d characters (%d)", MaxSubjectLength, len(firstLine))
 	}
 
 	if !conventionalCommitRegex().MatchString(firstLine) {

--- a/pk/conventional_commits_test.go
+++ b/pk/conventional_commits_test.go
@@ -1,6 +1,7 @@
 package pk
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -23,9 +24,6 @@ func TestValidateCommitMessage(t *testing.T) {
 		{"revert", "revert: undo change", false, ""},
 		{"style", "style: fix formatting", false, ""},
 		{"test", "test: add unit tests", false, ""},
-		{"wip", "wip: work in progress", false, ""},
-		{"merge type", "merge: merge branch", false, ""},
-
 		// Scoped messages.
 		{"scoped feat", "feat(api): add endpoint", false, ""},
 		{"scoped fix", "fix(auth): resolve token issue", false, ""},
@@ -42,6 +40,17 @@ func TestValidateCommitMessage(t *testing.T) {
 		// Multiline (only first line validated).
 		{"multiline valid", "feat: add feature\n\ndetailed description", false, ""},
 		{"multiline invalid", "Add feature\n\nfeat: this is body", true, "type prefix required"},
+
+		// Subject length (72 char limit).
+		{"exactly 72 chars", "feat: " + strings.Repeat("a", 66), false, ""},
+		{"73 chars", "feat: " + strings.Repeat("a", 67), true, "subject exceeds 72 characters"},
+
+		// Greedy scope rejected.
+		{"greedy scope", "feat(a)(b): add thing", true, "invalid format"},
+
+		// Removed types.
+		{"wip rejected", "wip: work in progress", true, "type prefix required"},
+		{"merge type rejected", "merge: merge branch", true, "type prefix required"},
 
 		// Invalid messages.
 		{"empty", "", true, "empty commit message"},

--- a/tasks/github/workflows/pr.yml.tmpl
+++ b/tasks/github/workflows/pr.yml.tmpl
@@ -21,7 +21,10 @@ jobs:
           GITHUB_TOKEN: {{`${{ github.token }}`}}
         with:
           requireScope: false
-          subjectPattern: ^(?![A-Z]).+$
+          subjectPattern: ^(?![A-Z]).{1,64}$
+          subjectPatternError: |
+            The subject must not start with an uppercase letter and must be at most 64 characters.
+            (Total limit is 72 characters including the type and scope prefix.)
           scopes: |
             .+
           types: |

--- a/tools/pk/conventional_commits.go
+++ b/tools/pk/conventional_commits.go
@@ -7,11 +7,14 @@ import (
 	"sync"
 )
 
+// MaxSubjectLength is the maximum allowed length for a commit subject line.
+const MaxSubjectLength = 72
+
 // ConventionalCommitTypes is the set of allowed conventional commit types.
 // Used by the -c builtin and the pr.yml workflow template.
 var ConventionalCommitTypes = []string{
 	"build", "chore", "ci", "docs", "feat", "fix",
-	"merge", "perf", "refactor", "revert", "style", "test", "wip",
+	"perf", "refactor", "revert", "style", "test",
 }
 
 var (
@@ -22,7 +25,7 @@ var (
 func conventionalCommitRegex() *regexp.Regexp {
 	commitRegexOnce.Do(func() {
 		types := strings.Join(ConventionalCommitTypes, "|")
-		pattern := fmt.Sprintf(`^(%s)(\(.+\))?!?: (?:[^A-Z]).+$`, types)
+		pattern := fmt.Sprintf(`^(%s)(\([^)]+\))?!?: (?:[^A-Z]).+$`, types)
 		commitRegex = regexp.MustCompile(pattern)
 	})
 	return commitRegex
@@ -42,6 +45,10 @@ func ValidateCommitMessage(msg string) error {
 	// Skip merge commits.
 	if strings.HasPrefix(firstLine, "Merge ") {
 		return nil
+	}
+
+	if len(firstLine) > MaxSubjectLength {
+		return fmt.Errorf("subject exceeds %d characters (%d)", MaxSubjectLength, len(firstLine))
 	}
 
 	if !conventionalCommitRegex().MatchString(firstLine) {

--- a/tools/pk/conventional_commits_test.go
+++ b/tools/pk/conventional_commits_test.go
@@ -1,6 +1,7 @@
 package pk
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -23,9 +24,6 @@ func TestValidateCommitMessage(t *testing.T) {
 		{"revert", "revert: undo change", false, ""},
 		{"style", "style: fix formatting", false, ""},
 		{"test", "test: add unit tests", false, ""},
-		{"wip", "wip: work in progress", false, ""},
-		{"merge type", "merge: merge branch", false, ""},
-
 		// Scoped messages.
 		{"scoped feat", "feat(api): add endpoint", false, ""},
 		{"scoped fix", "fix(auth): resolve token issue", false, ""},
@@ -42,6 +40,17 @@ func TestValidateCommitMessage(t *testing.T) {
 		// Multiline (only first line validated).
 		{"multiline valid", "feat: add feature\n\ndetailed description", false, ""},
 		{"multiline invalid", "Add feature\n\nfeat: this is body", true, "type prefix required"},
+
+		// Subject length (72 char limit).
+		{"exactly 72 chars", "feat: " + strings.Repeat("a", 66), false, ""},
+		{"73 chars", "feat: " + strings.Repeat("a", 67), true, "subject exceeds 72 characters"},
+
+		// Greedy scope rejected.
+		{"greedy scope", "feat(a)(b): add thing", true, "invalid format"},
+
+		// Removed types.
+		{"wip rejected", "wip: work in progress", true, "type prefix required"},
+		{"merge type rejected", "merge: merge branch", true, "type prefix required"},
 
 		// Invalid messages.
 		{"empty", "", true, "empty commit message"},


### PR DESCRIPTION
## Why

The conventional commit validation had several gaps:
- `wip` and `merge` were allowed as CC types (non-standard)
- No subject line length limit
- Greedy scope regex could match `feat(a)(b): desc` as valid

## What

- Remove `wip` and `merge` from `ConventionalCommitTypes`
- Add 72-character subject line length limit (`MaxSubjectLength`)
- Tighten scope regex from `(.+)` to `([^)]+)` to reject greedy matches
- Update `pr.yml.tmpl` with 64-char subject pattern (accounts for type/scope prefix)
- Add test cases for all new validations

## Notes

- Git merge commits (`Merge branch ...`) are still skipped via `HasPrefix` check
- Both `pk/` and `tools/pk/` copies are kept in sync