### PR TITLE
docs(pk): improve godoc clarity across public API

### DIFF
--- a/pk/cli.go
+++ b/pk/cli.go
@@ -14,8 +14,9 @@ import (
 	"github.com/fredrikaverpil/pocket/internal/scaffold"
 )
 
-// RunMain is the main CLI entry point that handles argument parsing and dispatch.
-// It's called from .pocket/main.go.
+// RunMain is the CLI entry point for Pocket. It parses arguments, builds
+// the execution plan, and dispatches task execution. Call this from your
+// .pocket/main.go with the project's [Config].
 func RunMain(cfg *Config) {
 	tracker, err := run(cfg)
 	if err != nil {
@@ -215,9 +216,8 @@ func printTaskHelp(ctx context.Context, task *Task) {
 	task.flagSet.PrintDefaults()
 }
 
-// ExecuteTask runs a single task by name with proper path context.
-// The name can include a suffix (e.g., "py-test:3.9") to select a specific task variant.
-// This is the public API for external callers.
+// ExecuteTask runs a single task by name from a pre-built [Plan].
+// The name can include a suffix (e.g., "py-test:3.9") to select a specific variant.
 func ExecuteTask(ctx context.Context, name string, p *Plan) error {
 	instance := findTaskByName(p, name)
 	if instance == nil {

--- a/pk/composition.go
+++ b/pk/composition.go
@@ -7,8 +7,12 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// Runnable represents a unit of execution in the task graph.
-// The run method is intentionally unexported to keep execution internals private.
+// Runnable is the core abstraction for composable units of work.
+// Tasks, Serial, Parallel, and WithOptions all produce Runnables that
+// can be nested to build execution trees.
+//
+// The run method is unexported; users compose Runnables via the
+// provided constructors rather than implementing the interface directly.
 type Runnable interface {
 	run(ctx context.Context) error
 }
@@ -19,9 +23,10 @@ func Serial(runnables ...Runnable) Runnable {
 	return &serial{runnables: runnables}
 }
 
-// Parallel composes multiple runnables to execute concurrently.
-// All runnables are started simultaneously, and execution waits for all to complete.
-// Returns the first error encountered, or nil if all succeed.
+// Parallel composes multiple runnables to execute concurrently with buffered output.
+// Each runnable's output is captured and flushed atomically on completion to prevent
+// interleaving. If any runnable fails, the shared context is cancelled and remaining
+// runnables exit early. A single runnable runs without buffering for real-time output.
 func Parallel(runnables ...Runnable) Runnable {
 	return &parallel{runnables: runnables}
 }

--- a/pk/context.go
+++ b/pk/context.go
@@ -136,10 +136,13 @@ func contextWithNameSuffix(ctx context.Context, suffix string) context.Context {
 // Environment Configuration
 // ═══════════════════════════════════════════════════════════════════════════════
 
-// EnvConfig holds environment variable overrides for command execution.
+// EnvConfig holds environment variable overrides applied to [Exec] calls.
+// Built up via [ContextWithEnv] and [ContextWithoutEnv].
 type EnvConfig struct {
-	Set    map[string]string // key -> value (replaces existing)
-	Filter []string          // prefixes to filter out
+	// Set contains environment variables to set (or replace). Keys are variable names.
+	Set map[string]string
+	// Filter contains prefixes of environment variables to remove.
+	Filter []string
 }
 
 // ContextWithEnv returns a new context that sets an environment variable for Exec calls.
@@ -172,8 +175,8 @@ func ContextWithoutEnv(ctx context.Context, prefix string) context.Context {
 	return context.WithValue(ctx, envKey{}, cfg)
 }
 
-// EnvConfigFromContext returns the environment config from the context.
-// Returns a copy to avoid mutating the original.
+// EnvConfigFromContext returns a copy of the environment config from the context.
+// Useful for inspecting what environment overrides are in effect.
 func EnvConfigFromContext(ctx context.Context) EnvConfig {
 	cfg, ok := ctx.Value(envKey{}).(EnvConfig)
 	if !ok {

--- a/pk/conventional_commits.go
+++ b/pk/conventional_commits.go
@@ -7,11 +7,13 @@ import (
 	"sync"
 )
 
-// MaxSubjectLength is the maximum allowed length for a commit subject line.
+// MaxSubjectLength is the maximum allowed length for a conventional commit
+// subject line (the first line of the commit message).
 const MaxSubjectLength = 72
 
-// ConventionalCommitTypes is the set of allowed conventional commit types.
-// Used by the -c builtin and the pr.yml workflow template.
+// ConventionalCommitTypes lists the allowed type prefixes for conventional
+// commit messages. Used by [ValidateCommitMessage] and the generated
+// GitHub Actions PR title validation workflow.
 var ConventionalCommitTypes = []string{
 	"build", "chore", "ci", "docs", "feat", "fix",
 	"perf", "refactor", "revert", "style", "test",

--- a/pk/doc.go
+++ b/pk/doc.go
@@ -1,0 +1,43 @@
+// Package pk is the core engine for Pocket, a composable task runner framework.
+//
+// Tasks are the fundamental units of work. Compose them into execution trees
+// using [Serial] and [Parallel], then configure path filtering and flag
+// overrides with [WithOptions].
+//
+//	var Config = &pk.Config{
+//	    Auto: pk.Serial(
+//	        Format,
+//	        pk.Parallel(Lint, Test),
+//	        Build,
+//	    ),
+//	}
+//
+// # Task Definition
+//
+// Define tasks as struct literals with a Do function or composed Body:
+//
+//	var Lint = &pk.Task{
+//	    Name:  "lint",
+//	    Usage: "run linters",
+//	    Do: func(ctx context.Context) error {
+//	        return pk.Exec(ctx, "golangci-lint", "run")
+//	    },
+//	}
+//
+// # Execution
+//
+// Use [Exec] to run external commands and [Do] to wrap Go functions as
+// [Runnable] values. Use [Printf], [Println], and [Errorf] for output
+// that works correctly in parallel contexts.
+//
+// # Path Filtering
+//
+// Use [WithOptions] with [WithPath], [WithSkipPath], or [WithDetect] to
+// control which directories tasks execute in. Use [WithFlags] and
+// [WithNameSuffix] to create task variants.
+//
+// # Plan Introspection
+//
+// [NewPlan] builds an execution plan from a [Config]. Access it at runtime
+// via [PlanFromContext] to generate CI workflows or custom tooling.
+package pk

--- a/pk/download/download.go
+++ b/pk/download/download.go
@@ -1,5 +1,7 @@
-// Package download provides utilities for downloading and extracting files.
-// It depends on the pk package for Runnable, Printf, and CreateSymlink.
+// Package download provides utilities for downloading, extracting, and
+// symlinking tool binaries. Use [Download] to create a [pk.Runnable] that
+// fetches a URL and optionally extracts and symlinks the result into
+// .pocket/bin/.
 package download
 
 import (
@@ -14,7 +16,7 @@ import (
 	"github.com/fredrikaverpil/pocket/pk"
 )
 
-// Opt configures download and extraction behavior.
+// Opt configures [Download] behavior.
 type Opt func(*downloadConfig)
 
 type downloadConfig struct {
@@ -56,14 +58,17 @@ func WithExtract(opt ExtractOpt) Opt {
 	}
 }
 
-// WithSymlink creates a symlink in .pocket/bin/ after extraction.
+// WithSymlink creates a symlink in .pocket/bin/ pointing to the extracted binary.
+// This makes the tool available to [pk.Exec] by name.
 func WithSymlink() Opt {
 	return func(cfg *downloadConfig) {
 		cfg.symlink = true
 	}
 }
 
-// WithSkipIfExists skips the download if the specified file exists.
+// WithSkipIfExists skips the download if the file at path already exists.
+// Use this with a path like pk.FromToolsDir("tool", "v1.0", "tool") to
+// avoid re-downloading on every run.
 func WithSkipIfExists(path string) Opt {
 	return func(cfg *downloadConfig) {
 		cfg.skipIfExists = path
@@ -71,13 +76,17 @@ func WithSkipIfExists(path string) Opt {
 }
 
 // WithOutputName sets the output filename for "gz" format extraction.
+// Required when format is "gz" since gzip files don't contain the original filename.
 func WithOutputName(name string) Opt {
 	return func(cfg *downloadConfig) {
 		cfg.outputName = name
 	}
 }
 
-// Download creates a Runnable that fetches a URL and optionally extracts it.
+// Download creates a [pk.Runnable] that fetches a URL and optionally
+// extracts, renames, and symlinks the downloaded file.
+// Configure behavior with [WithDestDir], [WithFormat], [WithExtract],
+// [WithSymlink], and [WithSkipIfExists].
 func Download(url string, opts ...Opt) pk.Runnable {
 	return pk.Do(func(ctx context.Context) error {
 		return download(ctx, url, opts...)

--- a/pk/download/extract.go
+++ b/pk/download/extract.go
@@ -11,7 +11,8 @@ import (
 	"strings"
 )
 
-// ExtractOpt configures extraction behavior.
+// ExtractOpt configures how archives are unpacked by [ExtractTarGz],
+// [ExtractTar], and [ExtractZip].
 type ExtractOpt func(*extractConfig)
 
 type extractConfig struct {

--- a/pk/download/symlink.go
+++ b/pk/download/symlink.go
@@ -98,7 +98,7 @@ func CreateSymlinkWithCompanions(binaryPath string, companions ...string) (strin
 	return linkPath, nil
 }
 
-// CopyFile copies a file from src to dst.
+// CopyFile copies a file from src to dst, preserving executable permissions.
 func CopyFile(src, dst string) error {
 	data, err := os.ReadFile(src)
 	if err != nil {

--- a/pk/exec.go
+++ b/pk/exec.go
@@ -19,8 +19,7 @@ import (
 // waitDelay is the time to wait after sending SIGINT before sending SIGKILL.
 const waitDelay = 5 * time.Second
 
-// Do creates a Runnable that executes a dynamic function.
-// Use this when command arguments need to be computed at runtime.
+// Do wraps a Go function as a [Runnable] for use in task composition.
 //
 //	pk.Do(func(ctx context.Context) error {
 //	    return pk.Exec(ctx, "golangci-lint", "run", "--fix", "./...")
@@ -67,19 +66,17 @@ func isTerminal(f *os.File) bool {
 	return term.IsTerminal(int(f.Fd()))
 }
 
-// Exec executes a command with .pocket/bin prepended to PATH.
-// The command runs in the directory specified by PathFromContext(ctx).
+// Exec runs an external command with .pocket/bin prepended to PATH.
+// The command runs in the directory from [PathFromContext].
 //
-// Environment variables can be customized using ContextWithEnv and ContextWithoutEnv:
+// Output handling depends on verbose mode (-v flag):
+//   - Verbose: output streams to stdout/stderr in real-time.
+//   - Non-verbose: output is captured and shown only on error or when
+//     warning-like patterns are detected (see [DefaultNoticePatterns]).
 //
-//	ctx = pk.ContextWithEnv(ctx, "MY_VAR=value")
-//	ctx = pk.ContextWithoutEnv(ctx, "UNWANTED_PREFIX")
-//	pk.Exec(ctx, "mycmd", "arg1")
-//
-// If verbose mode is enabled, command output is streamed to context output.
-// Otherwise, output is captured and only shown on error.
-//
-// Commands are terminated gracefully: SIGINT first, then SIGKILL after WaitDelay.
+// Environment variables can be customized via [ContextWithEnv] and [ContextWithoutEnv].
+// On Unix, commands receive SIGINT on context cancellation for graceful shutdown,
+// followed by SIGKILL after 5 seconds.
 func Exec(ctx context.Context, name string, args ...string) error {
 	colorEnvOnce.Do(initColorEnv)
 
@@ -134,8 +131,10 @@ func Exec(ctx context.Context, name string, args ...string) error {
 	return nil
 }
 
-// DefaultNoticePatterns are the default substrings used to detect
-// warning-like output from commands.
+// DefaultNoticePatterns are the substrings used to detect warning-like output
+// from commands when not in verbose mode. If any pattern matches (case-insensitive),
+// the output is shown to the user even though the command succeeded.
+// Override per scope with [WithNoticePatterns].
 var DefaultNoticePatterns = []string{"warn", "deprecat", "notice", "caution", "error"}
 
 // noticePatternsKey is the context key for custom notice patterns.

--- a/pk/flags.go
+++ b/pk/flags.go
@@ -242,9 +242,12 @@ func diffStructs(defaults, overrides any) (map[string]any, error) {
 	return diff, nil
 }
 
-// GetFlags retrieves the resolved flags struct from context.
-// Panics with a flagError if no flags are in context.
-// The panic is recovered by task.run() and surfaced as a returned error.
+// GetFlags retrieves the resolved flags for a task from context.
+// It returns a struct of type T populated with the task's default values,
+// any overrides from [WithFlags], and CLI flag values (highest priority).
+//
+// Must be called from within a task's Do function. If no flags are available
+// in context, the task returns an error.
 func GetFlags[T any](ctx context.Context) T {
 	var zero T
 	m := taskFlagsFromContext(ctx)

--- a/pk/output.go
+++ b/pk/output.go
@@ -12,7 +12,9 @@ import (
 // Used for stdout/stderr redirection during task execution.
 type outputKey struct{}
 
-// Output holds stdout and stderr writers for task output.
+// Output holds the stdout and stderr writers used by [Printf], [Println],
+// [Errorf], and [Exec]. In parallel execution, each goroutine receives
+// a buffered Output to prevent interleaved output.
 type Output struct {
 	Stdout io.Writer
 	Stderr io.Writer
@@ -71,19 +73,22 @@ func outputFromContext(ctx context.Context) *Output {
 	return StdOutput()
 }
 
-// Printf formats and prints to the output in the context.
+// Printf formats and writes to the context's stdout.
+// Use this instead of [fmt.Printf] to ensure correct output in parallel tasks.
 func Printf(ctx context.Context, format string, a ...any) {
 	out := outputFromContext(ctx)
 	fmt.Fprintf(out.Stdout, format, a...)
 }
 
-// Println prints to the output in the context.
+// Println writes to the context's stdout, appending a newline.
+// Use this instead of [fmt.Println] to ensure correct output in parallel tasks.
 func Println(ctx context.Context, a ...any) {
 	out := outputFromContext(ctx)
 	fmt.Fprintln(out.Stdout, a...)
 }
 
-// Errorf formats and prints to the error output in the context.
+// Errorf formats and writes to the context's stderr.
+// Use this instead of [fmt.Fprintf](os.Stderr, ...) to ensure correct output in parallel tasks.
 func Errorf(ctx context.Context, format string, a ...any) {
 	out := outputFromContext(ctx)
 	fmt.Fprintf(out.Stderr, format, a...)

--- a/pk/plan.go
+++ b/pk/plan.go
@@ -19,17 +19,12 @@ func PlanFromContext(ctx context.Context) *Plan {
 	return nil
 }
 
-// Plan represents the execution plan created from a Config.
-// It preserves the composition tree structure while extracting metadata.
+// Plan represents the execution plan created from a [Config].
+// It is built once by [NewPlan], which analyzes both the composition tree
+// and the filesystem, then reused throughout execution.
 //
-// The plan is created once by analyzing both the Config and filesystem,
-// then reused throughout execution. This is a PUBLIC API - users can access
-// the plan to inspect what will execute, build custom tooling, or implement
-// their own visualization.
-//
-// IMPORTANT: While Plan is exported for introspection, the composition types
-// (serial, parallel, pathFilter) remain internal. Users should not rely on
-// type assertions against Runnable - the composition structure may change.
+// Use [Plan.Tasks] to inspect what will execute, and [PlanFromContext]
+// to access the plan from within a task's Do function.
 type Plan struct {
 	// tree is the composition tree that preserves dependencies and structure.
 	// Execution walks this tree, respecting Serial/Parallel composition.
@@ -57,8 +52,8 @@ type Plan struct {
 	shimConfig *ShimConfig
 }
 
-// ShimConfig returns the resolved shim configuration.
-// If no shim config was set in Config, defaults to POSIX only.
+// ShimConfig returns the resolved shim configuration from the [Config].
+// Defaults to POSIX only (pok) if no [ShimConfig] was provided.
 func (p *Plan) ShimConfig() *ShimConfig {
 	if p.shimConfig == nil {
 		return &ShimConfig{Posix: true}
@@ -81,9 +76,9 @@ type pathInfo struct {
 	resolvedPaths []string
 }
 
-// NewPlan creates an execution plan from a Config.
-// It walks the composition tree to extract tasks and analyzes the filesystem.
-// The filesystem is traversed ONCE during plan creation.
+// NewPlan creates an execution plan from a [Config].
+// It walks the composition tree to extract tasks, resolves path filters
+// against the filesystem (traversed once), and pre-computes flag overrides.
 func NewPlan(cfg *Config) (*Plan, error) {
 	gitRoot := findGitRoot()
 
@@ -531,19 +526,26 @@ func deriveModuleDirectories(pathMappings map[string]pathInfo) []string {
 	return dirs
 }
 
-// TaskInfo represents a task for introspection.
-// This is the public type for CI/CD integration (e.g., per-task workflow generation).
+// TaskInfo describes a task in the execution plan.
+// Returned by [Plan.Tasks] for introspection, CI workflow generation,
+// and custom tooling.
 type TaskInfo struct {
-	Name   string         `json:"name"`            // CLI command name
-	Usage  string         `json:"usage,omitempty"` // Description/help text
-	Paths  []string       `json:"paths"`           // Directories this task runs in (resolved)
-	Flags  map[string]any `json:"flags,omitempty"` // Flag overrides set via pk.WithFlags()
-	Hidden bool           `json:"hidden"`          // Whether task is hidden from help
-	Manual bool           `json:"manual"`          // Whether task is manual-only
+	// Name is the effective task name, including any suffix (e.g., "py-test:3.9").
+	Name string `json:"name"`
+	// Usage is the short description shown in help output.
+	Usage string `json:"usage,omitempty"`
+	// Paths lists the directories where this task will execute.
+	Paths []string `json:"paths"`
+	// Flags contains flag overrides applied via [WithFlags].
+	Flags map[string]any `json:"flags,omitempty"`
+	// Hidden indicates the task is excluded from CLI help listings.
+	Hidden bool `json:"hidden"`
+	// Manual indicates the task only runs when explicitly invoked, not on bare ./pok.
+	Manual bool `json:"manual"`
 }
 
-// Tasks returns task information for all tasks in the plan.
-// This is the public introspection API for CI/CD integration.
+// Tasks returns information about all tasks in the plan.
+// Task names include any suffix from [WithNameSuffix] (e.g., "py-test:3.9").
 func (p *Plan) Tasks() []TaskInfo {
 	if p == nil {
 		return nil


### PR DESCRIPTION
## Why?

The godoc comments across the `pk` and `pk/download` packages had
inconsistencies: internal jargon leaked into public docs, some symbols
lacked context about their purpose, and cross-references between related
symbols were missing. Users reading `go doc` output couldn't easily
understand how the API fits together.

## What?

- Add package-level doc comment (`pk/doc.go`) with overview, task
  definition, execution, path filtering, and plan introspection sections
- Replace internal terminology with user-focused descriptions (e.g.,
  `GetFlags` no longer mentions `flagError` panic internals)
- Add `[Symbol]` doc links between related symbols (e.g., `Exec` links
  to `PathFromContext`, `DefaultNoticePatterns`, `ContextWithEnv`)
- Clarify `Parallel` behavior: buffered output, context cancellation,
  single-item optimization
- Improve `Exec` doc: structured verbose/non-verbose behavior, graceful
  shutdown details
- Remove redundant "This is the public API" phrases from exported symbols
- Clean up `Plan` doc: remove internal-style markers, add links to
  `Tasks()` and `PlanFromContext`
- Expand `TaskInfo` with proper field-level doc comments
- Add parallel-safety guidance to `Printf`, `Println`, `Errorf`
- Improve `download` package doc and option docs (`WithSymlink`,
  `WithSkipIfExists`, `WithOutputName`)