### PR TITLE
feat(docs): categorize WithOptions into distinct option types

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,13 +178,13 @@ var Config = &pk.Config{
 
 Wrap tasks with `WithOptions` to customize behavior:
 
-- **Auto-detection**: `WithDetect(golang.Detect())` finds all `go.mod`
-  directories
-- **Path filtering**: `WithPath("services/*")` runs only in matching paths
-- **Path exclusion**: `WithSkipPath("vendor")` skips specific directories
-- **Flag overrides**: `WithFlags(FlagsStruct{Field: value})` sets task-specific
-  flags
-- [and more...](./docs/reference.md)
+- **Path scoping**: `WithPath`, `WithSkipPath`, `WithDetect` — control which
+  directories tasks run in
+- **Task control**: `WithSkipTask`, `WithNameSuffix`, `WithForceRun` — skip,
+  rename, or force-rerun tasks
+- **Flag overrides**: `WithFlags` — override task-specific flag defaults
+- **Output**: `WithNoticePatterns` — customize warning detection patterns
+- [Full reference...](./docs/reference.md#task-options)
 
 ```go
 pk.WithOptions(

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -31,6 +31,7 @@ defining your first task to building complex CI pipelines.
   - [Serial Execution](#serial-execution)
   - [Parallel Execution](#parallel-execution)
   - [Task Deduplication](#task-deduplication)
+- [Options](#options)
 - [Path Filtering](#path-filtering)
   - [Include and Exclude](#include-and-exclude)
   - [Auto-Detection](#auto-detection)
@@ -842,30 +843,39 @@ pk.WithOptions(
 
 ---
 
-## Path Filtering
+## Options
 
-In monorepos or multi-module projects, you often want to run tasks only in
-specific directories. All path patterns are **regular expressions**.
+`pk.WithOptions` wraps a `Runnable` with scoped execution options. Options fall
+into four categories:
 
-### Option Types
+**Path scoping** — control which directories tasks run in:
 
-`pk.WithOptions` accepts two types of options:
+| Option                         | Description                      |
+| :----------------------------- | :------------------------------- |
+| `pk.WithPath(patterns...)`     | Only run in matching directories |
+| `pk.WithSkipPath(patterns...)` | Skip matching directories        |
+| `pk.WithDetect(fn)`            | Auto-detect directories          |
 
-**Generic options (`pk.With*`)** work with any task:
+**Task control** — skip, rename, or force-rerun tasks:
 
 | Option                               | Description                            |
 | :----------------------------------- | :------------------------------------- |
-| `pk.WithPath(patterns...)`           | Only run in matching directories       |
-| `pk.WithSkipPath(patterns...)`       | Skip matching directories              |
 | `pk.WithSkipTask(task)`              | Remove a task from scope               |
 | `pk.WithSkipTask(task, patterns...)` | Skip a task in matching directories    |
-| `pk.WithDetect(fn)`                  | Auto-detect directories                |
 | `pk.WithNameSuffix(suffix)`          | Add suffix to task names (e.g., `:v2`) |
-| `pk.WithFlags(flagsStruct)`          | Override a task's flags                |
 | `pk.WithForceRun()`                  | Disable deduplication                  |
-| `pk.WithNoticePatterns(...)`         | Override warning detection patterns    |
 
-Use `pk.WithFlags()` to set task flags explicitly:
+**Flag overrides** — override task-specific flag defaults:
+
+| Option                      | Description             |
+| :-------------------------- | :---------------------- |
+| `pk.WithFlags(flagsStruct)` | Override a task's flags |
+
+**Output** — customize warning detection:
+
+| Option                       | Description                         |
+| :--------------------------- | :---------------------------------- |
+| `pk.WithNoticePatterns(...)` | Override warning detection patterns |
 
 ```go
 pk.WithOptions(
@@ -890,6 +900,13 @@ func EnableFeature() pk.Option {
     return pk.WithFlags(MyFlags{Feature: true})
 }
 ```
+
+---
+
+## Path Filtering
+
+In monorepos or multi-module projects, you often want to run tasks only in
+specific directories. All path patterns are **regular expressions**.
 
 ### Include and Exclude
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -8,6 +8,10 @@ Technical reference for the `github.com/fredrikaverpil/pocket/pk` and
 - [Configuration](#configuration)
 - [Composition](#composition)
 - [Task Options](#task-options)
+  - [Path Scoping](#path-scoping)
+  - [Task Control](#task-control)
+  - [Flag Overrides](#flag-overrides)
+  - [Output](#output)
 - [Detection](#detection)
 - [Tasks](#tasks)
 - [Execution](#execution)
@@ -196,22 +200,36 @@ pk.WithOptions(Test, pk.WithPath("services"))
 
 ## Task Options
 
-Options passed to `WithOptions` to control where and how tasks execute.
+Options passed to `WithOptions` to control where and how tasks execute. Options
+fall into four categories:
 
-### Generic Options (pk.With\*)
+### Path Scoping
 
-These options work with any task:
+| Option         | Description                                           |
+| :------------- | :---------------------------------------------------- |
+| `WithPath`     | Run only in directories matching the regex patterns   |
+| `WithSkipPath` | Skip directories matching the regex patterns          |
+| `WithDetect`   | Dynamically discover paths using a detection function |
 
-| Option               | Description                                                 |
-| :------------------- | :---------------------------------------------------------- |
-| `WithPath`           | Run only in directories matching the regex patterns         |
-| `WithSkipPath`       | Skip directories matching the regex patterns                |
-| `WithSkipTask`       | Skip a task entirely, or from directories matching patterns |
-| `WithDetect`         | Dynamically discover paths using a detection function       |
-| `WithNameSuffix`     | Create a named variant (e.g., `py-test` → `py-test:3.9`)    |
-| `WithForceRun`       | Bypass task deduplication for the wrapped runnable          |
-| `WithFlags`          | Set flag overrides for a task in scope                      |
-| `WithNoticePatterns` | Override warning detection patterns for the scope           |
+### Task Control
+
+| Option           | Description                                                 |
+| :--------------- | :---------------------------------------------------------- |
+| `WithSkipTask`   | Skip a task entirely, or from directories matching patterns |
+| `WithNameSuffix` | Create a named variant (e.g., `py-test` → `py-test:3.9`)    |
+| `WithForceRun`   | Bypass task deduplication for the wrapped runnable          |
+
+### Flag Overrides
+
+| Option      | Description                            |
+| :---------- | :------------------------------------- |
+| `WithFlags` | Set flag overrides for a task in scope |
+
+### Output
+
+| Option               | Description                                   |
+| :------------------- | :-------------------------------------------- |
+| `WithNoticePatterns` | Override warning detection patterns for scope |
 
 ```go
 pk.WithOptions(

--- a/pk/options.go
+++ b/pk/options.go
@@ -104,8 +104,8 @@ func WithForceRun() Option {
 //
 //	pk.WithOptions(
 //	    golang.Tasks(),
-//	    pk.WithSkipPath("vendor"), // Excludes vendor/ from the Go task scope
-//	    pk.WithFlags(golang.TestFlags{Race: true}),
+//	    pk.WithDetect(golang.Detect()),   // Discover Go module directories
+//	    pk.WithSkipPath("vendor"),        // Excludes vendor/ from the scope
 //	)
 func WithDetect(fn DetectFunc) Option {
 	return func(pf *pathFilter) {
@@ -139,9 +139,9 @@ func WithNameSuffix(suffix string) Option {
 	}
 }
 
-// WithOptions wraps a Runnable with path filtering options.
-// The wrapped Runnable will execute in directories determined by
-// include/exclude patterns resolved against the filesystem.
+// WithOptions wraps a Runnable with scoped execution options.
+// Options can control path filtering, flag overrides, task skipping,
+// deduplication, output patterns, and task naming within the scope.
 func WithOptions(r Runnable, opts ...Option) Runnable {
 	pf := &pathFilter{
 		inner:        r,


### PR DESCRIPTION
## Why?

The WithOptions documentation listed all options as a flat list, making it unclear that they serve fundamentally different purposes (path scoping vs task control vs flag overrides vs output). The README link to the reference also pointed to the file root instead of the relevant section.

## What?

- Categorize options into four groups (path scoping, task control, flag overrides, output) in README, guide.md, and reference.md
- Fix broken `[and more...]` link in README to point to `reference.md#task-options`
- Broaden `WithOptions` Go doc from "path filtering options" to describe full scope
- Fix `WithDetect` Go doc example to actually demonstrate `WithDetect`
- Update TOCs in guide.md and reference.md