### PR TITLE
docs: consolidate WithOptions documentation into single table

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,8 @@ var Config = &pk.Config{
 
 Wrap tasks with `WithOptions` to customize behavior:
 
-- **Auto-detection**: `WithDetect(golang.Detect())` finds all `go.mod`
-  directories
+- **Auto-detection**: `WithDetect` scans for marker files (e.g. `go.mod`,
+  `pyproject.toml`) to run tasks only in matching directories
 - **Path filtering**: `WithPath("services/*")` runs only in matching paths
 - **Path exclusion**: `WithSkipPath("vendor")` skips specific directories
 - **Flag overrides**: `WithFlags(FlagsStruct{Field: value})` sets task-specific

--- a/README.md
+++ b/README.md
@@ -178,13 +178,13 @@ var Config = &pk.Config{
 
 Wrap tasks with `WithOptions` to customize behavior:
 
-- **Path scoping**: `WithPath`, `WithSkipPath`, `WithDetect` — control which
-  directories tasks run in
-- **Task control**: `WithSkipTask`, `WithNameSuffix`, `WithForceRun` — skip,
-  rename, or force-rerun tasks
-- **Flag overrides**: `WithFlags` — override task-specific flag defaults
-- **Output**: `WithNoticePatterns` — customize warning detection patterns
-- [Full reference...](./docs/reference.md#task-options)
+- **Auto-detection**: `WithDetect(golang.Detect())` finds all `go.mod`
+  directories
+- **Path filtering**: `WithPath("services/*")` runs only in matching paths
+- **Path exclusion**: `WithSkipPath("vendor")` skips specific directories
+- **Flag overrides**: `WithFlags(FlagsStruct{Field: value})` sets task-specific
+  flags
+- [and more...](./docs/reference.md)
 
 ```go
 pk.WithOptions(

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -31,6 +31,7 @@ defining your first task to building complex CI pipelines.
   - [Serial Execution](#serial-execution)
   - [Parallel Execution](#parallel-execution)
   - [Task Deduplication](#task-deduplication)
+- [Options](#options)
 - [Path Filtering](#path-filtering)
   - [Include and Exclude](#include-and-exclude)
   - [Auto-Detection](#auto-detection)
@@ -842,16 +843,9 @@ pk.WithOptions(
 
 ---
 
-## Path Filtering
+## Options
 
-In monorepos or multi-module projects, you often want to run tasks only in
-specific directories. All path patterns are **regular expressions**.
-
-### Option Types
-
-`pk.WithOptions` accepts two types of options:
-
-**Generic options (`pk.With*`)** work with any task:
+`pk.WithOptions` wraps a `Runnable` with scoped execution options:
 
 | Option                               | Description                            |
 | :----------------------------------- | :------------------------------------- |
@@ -890,6 +884,13 @@ func EnableFeature() pk.Option {
     return pk.WithFlags(MyFlags{Feature: true})
 }
 ```
+
+---
+
+## Path Filtering
+
+In monorepos or multi-module projects, you often want to run tasks only in
+specific directories. All path patterns are **regular expressions**.
 
 ### Include and Exclude
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -31,7 +31,6 @@ defining your first task to building complex CI pipelines.
   - [Serial Execution](#serial-execution)
   - [Parallel Execution](#parallel-execution)
   - [Task Deduplication](#task-deduplication)
-- [Options](#options)
 - [Path Filtering](#path-filtering)
   - [Include and Exclude](#include-and-exclude)
   - [Auto-Detection](#auto-detection)
@@ -843,39 +842,30 @@ pk.WithOptions(
 
 ---
 
-## Options
+## Path Filtering
 
-`pk.WithOptions` wraps a `Runnable` with scoped execution options. Options fall
-into four categories:
+In monorepos or multi-module projects, you often want to run tasks only in
+specific directories. All path patterns are **regular expressions**.
 
-**Path scoping** — control which directories tasks run in:
+### Option Types
 
-| Option                         | Description                      |
-| :----------------------------- | :------------------------------- |
-| `pk.WithPath(patterns...)`     | Only run in matching directories |
-| `pk.WithSkipPath(patterns...)` | Skip matching directories        |
-| `pk.WithDetect(fn)`            | Auto-detect directories          |
+`pk.WithOptions` accepts two types of options:
 
-**Task control** — skip, rename, or force-rerun tasks:
+**Generic options (`pk.With*`)** work with any task:
 
 | Option                               | Description                            |
 | :----------------------------------- | :------------------------------------- |
+| `pk.WithPath(patterns...)`           | Only run in matching directories       |
+| `pk.WithSkipPath(patterns...)`       | Skip matching directories              |
 | `pk.WithSkipTask(task)`              | Remove a task from scope               |
 | `pk.WithSkipTask(task, patterns...)` | Skip a task in matching directories    |
+| `pk.WithDetect(fn)`                  | Auto-detect directories                |
 | `pk.WithNameSuffix(suffix)`          | Add suffix to task names (e.g., `:v2`) |
+| `pk.WithFlags(flagsStruct)`          | Override a task's flags                |
 | `pk.WithForceRun()`                  | Disable deduplication                  |
+| `pk.WithNoticePatterns(...)`         | Override warning detection patterns    |
 
-**Flag overrides** — override task-specific flag defaults:
-
-| Option                      | Description             |
-| :-------------------------- | :---------------------- |
-| `pk.WithFlags(flagsStruct)` | Override a task's flags |
-
-**Output** — customize warning detection:
-
-| Option                       | Description                         |
-| :--------------------------- | :---------------------------------- |
-| `pk.WithNoticePatterns(...)` | Override warning detection patterns |
+Use `pk.WithFlags()` to set task flags explicitly:
 
 ```go
 pk.WithOptions(
@@ -900,13 +890,6 @@ func EnableFeature() pk.Option {
     return pk.WithFlags(MyFlags{Feature: true})
 }
 ```
-
----
-
-## Path Filtering
-
-In monorepos or multi-module projects, you often want to run tasks only in
-specific directories. All path patterns are **regular expressions**.
 
 ### Include and Exclude
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -8,10 +8,6 @@ Technical reference for the `github.com/fredrikaverpil/pocket/pk` and
 - [Configuration](#configuration)
 - [Composition](#composition)
 - [Task Options](#task-options)
-  - [Path Scoping](#path-scoping)
-  - [Task Control](#task-control)
-  - [Flag Overrides](#flag-overrides)
-  - [Output](#output)
 - [Detection](#detection)
 - [Tasks](#tasks)
 - [Execution](#execution)
@@ -200,36 +196,22 @@ pk.WithOptions(Test, pk.WithPath("services"))
 
 ## Task Options
 
-Options passed to `WithOptions` to control where and how tasks execute. Options
-fall into four categories:
+Options passed to `WithOptions` to control where and how tasks execute.
 
-### Path Scoping
+### Generic Options (pk.With\*)
 
-| Option         | Description                                           |
-| :------------- | :---------------------------------------------------- |
-| `WithPath`     | Run only in directories matching the regex patterns   |
-| `WithSkipPath` | Skip directories matching the regex patterns          |
-| `WithDetect`   | Dynamically discover paths using a detection function |
+These options work with any task:
 
-### Task Control
-
-| Option           | Description                                                 |
-| :--------------- | :---------------------------------------------------------- |
-| `WithSkipTask`   | Skip a task entirely, or from directories matching patterns |
-| `WithNameSuffix` | Create a named variant (e.g., `py-test` → `py-test:3.9`)    |
-| `WithForceRun`   | Bypass task deduplication for the wrapped runnable          |
-
-### Flag Overrides
-
-| Option      | Description                            |
-| :---------- | :------------------------------------- |
-| `WithFlags` | Set flag overrides for a task in scope |
-
-### Output
-
-| Option               | Description                                   |
-| :------------------- | :-------------------------------------------- |
-| `WithNoticePatterns` | Override warning detection patterns for scope |
+| Option               | Description                                                 |
+| :------------------- | :---------------------------------------------------------- |
+| `WithPath`           | Run only in directories matching the regex patterns         |
+| `WithSkipPath`       | Skip directories matching the regex patterns                |
+| `WithSkipTask`       | Skip a task entirely, or from directories matching patterns |
+| `WithDetect`         | Dynamically discover paths using a detection function       |
+| `WithNameSuffix`     | Create a named variant (e.g., `py-test` → `py-test:3.9`)    |
+| `WithForceRun`       | Bypass task deduplication for the wrapped runnable          |
+| `WithFlags`          | Set flag overrides for a task in scope                      |
+| `WithNoticePatterns` | Override warning detection patterns for the scope           |
 
 ```go
 pk.WithOptions(

--- a/pk/options.go
+++ b/pk/options.go
@@ -104,8 +104,8 @@ func WithForceRun() Option {
 //
 //	pk.WithOptions(
 //	    golang.Tasks(),
-//	    pk.WithDetect(golang.Detect()),   // Discover Go module directories
-//	    pk.WithSkipPath("vendor"),        // Excludes vendor/ from the scope
+//	    pk.WithSkipPath("vendor"), // Excludes vendor/ from the Go task scope
+//	    pk.WithFlags(golang.TestFlags{Race: true}),
 //	)
 func WithDetect(fn DetectFunc) Option {
 	return func(pf *pathFilter) {
@@ -139,9 +139,9 @@ func WithNameSuffix(suffix string) Option {
 	}
 }
 
-// WithOptions wraps a Runnable with scoped execution options.
-// Options can control path filtering, flag overrides, task skipping,
-// deduplication, output patterns, and task naming within the scope.
+// WithOptions wraps a Runnable with path filtering options.
+// The wrapped Runnable will execute in directories determined by
+// include/exclude patterns resolved against the filesystem.
 func WithOptions(r Runnable, opts ...Option) Runnable {
 	pf := &pathFilter{
 		inner:        r,

--- a/pk/options.go
+++ b/pk/options.go
@@ -104,8 +104,8 @@ func WithForceRun() Option {
 //
 //	pk.WithOptions(
 //	    golang.Tasks(),
-//	    pk.WithSkipPath("vendor"), // Excludes vendor/ from the Go task scope
-//	    pk.WithFlags(golang.TestFlags{Race: true}),
+//	    pk.WithDetect(golang.Detect()),   // Discover Go module directories
+//	    pk.WithSkipPath("vendor"),        // Excludes vendor/ from the scope
 //	)
 func WithDetect(fn DetectFunc) Option {
 	return func(pf *pathFilter) {
@@ -139,9 +139,9 @@ func WithNameSuffix(suffix string) Option {
 	}
 }
 
-// WithOptions wraps a Runnable with path filtering options.
-// The wrapped Runnable will execute in directories determined by
-// include/exclude patterns resolved against the filesystem.
+// WithOptions wraps a Runnable with scoped execution options.
+// Options can control path filtering, flag overrides, task skipping,
+// deduplication, output patterns, and task naming within the scope.
 func WithOptions(r Runnable, opts ...Option) Runnable {
 	pf := &pathFilter{
 		inner:        r,


### PR DESCRIPTION
## Why?

The four separate option category tables (Path Scoping, Task Control, Flag Overrides, Output) added unnecessary fragmentation. A single table is easier to scan and maintain.

## What?

- Consolidate four option tables into one in guide and reference docs
- Simplify README options list to example-based bullets
- Keep Options as its own top-level guide section (separate from Path Filtering)