### PR TITLE
feat(renovate): add 3-day minimum release age

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "minimumReleaseAge": "3 days",
   "postUpdateOptions": [
     "gomodTidy"
   ],


### PR DESCRIPTION
## Why?

Reduce exposure to compromised dependency releases by introducing a cooldown period. Recent incidents like the [Trivy v0.69.4 supply chain attack](https://www.stepsecurity.io/blog/trivy-compromised-a-second-time---malicious-v0-69-4-release) demonstrate the risk of auto-merging freshly published versions.

## What?

- Add `minimumReleaseAge: "3 days"` as a global default in `renovate.json`