### PR TITLE
feat(github): add ExternalWorkflows validation to workflow task

### DIFF
--- a/tasks/github/workflows.go
+++ b/tasks/github/workflows.go
@@ -86,6 +86,11 @@ type WorkflowFlags struct {
 	// Programmatic-only fields (no flag tag — set via pk.WithFlags, not CLI).
 	Platforms               []Platform
 	PerPocketTaskJobOptions map[string]PerPocketTaskJobOption
+
+	// ExternalWorkflows lists workflow filenames not managed by Pocket
+	// (e.g. "renovate.yml"). The task validates these files exist in
+	// .github/workflows/ and fails if any are missing.
+	ExternalWorkflows []string
 }
 
 // Workflows bootstraps GitHub workflow files into .github/workflows/.
@@ -230,6 +235,22 @@ func runWorkflows(ctx context.Context) error {
 			return fmt.Errorf("generate pocket-pertask workflow: %w", err)
 		}
 		copied++
+	}
+
+	// Validate that declared external workflows exist on disk.
+	for _, name := range f.ExternalWorkflows {
+		extPath := filepath.Join(workflowDir, name)
+		if _, err := os.Stat(extPath); err != nil {
+			return fmt.Errorf(
+				"external workflow %q not found in %s — remove it from ExternalWorkflows: %w",
+				name,
+				workflowDir,
+				err,
+			)
+		}
+		if verbose {
+			run.Printf(ctx, "  Verified external workflow: %s\n", name)
+		}
 	}
 
 	if verbose && copied > 0 {


### PR DESCRIPTION
## Why?

When using `github.Tasks()` in a Pocket config, all managed workflow files are cleaned up before regeneration. There's no way to declare that certain workflows (e.g. Renovate, Dependabot) are expected to exist but not managed by Pocket. If such a workflow is removed upstream, there's no signal that the config is stale.

## What?

- Add `ExternalWorkflows []string` field to `WorkflowFlags` (programmatic-only, no CLI flag)
- Validate declared external workflow files exist on disk after generation
- Fail with an actionable error if any are missing, prompting removal from config