### PR TITLE
fix(github): skip external workflows during managed file cleanup

### DIFF
--- a/tasks/github/workflows.go
+++ b/tasks/github/workflows.go
@@ -190,6 +190,9 @@ func runWorkflows(ctx context.Context) error {
 		if !wf.include {
 			continue
 		}
+		if _, external := externalSet[wf.outFile]; external {
+			continue
+		}
 
 		destPath := filepath.Join(workflowDir, wf.outFile)
 

--- a/tasks/github/workflows.go
+++ b/tasks/github/workflows.go
@@ -166,9 +166,19 @@ func runWorkflows(ctx context.Context) error {
 		allManagedFiles = append(allManagedFiles, wf.outFile)
 	}
 
+	// Build set of external workflows to skip during cleanup.
+	externalSet := make(map[string]struct{}, len(f.ExternalWorkflows))
+	for _, name := range f.ExternalWorkflows {
+		externalSet[name] = struct{}{}
+	}
+
 	// Clean up managed workflow files before generating.
 	// This ensures disabled workflows are removed.
+	// Files declared as external workflows are skipped.
 	for _, outFile := range allManagedFiles {
+		if _, external := externalSet[outFile]; external {
+			continue
+		}
 		destPath := filepath.Join(workflowDir, outFile)
 		if err := os.Remove(destPath); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("remove %s: %w", outFile, err)


### PR DESCRIPTION
## Why?

A file like `gh-pages.yml` declared in `ExternalWorkflows` shares a name with a managed Pocket template. The cleanup step deletes all managed files before regeneration, so the external file gets removed — then the existence validation fails.

## What?

- Build a set of `ExternalWorkflows` names and skip them during managed file cleanup