### PR TITLE
fix(pagefind): use non-extended release archive

### DIFF
--- a/tools/pagefind/pagefind.go
+++ b/tools/pagefind/pagefind.go
@@ -19,7 +19,7 @@ const Name = "pagefind"
 // renovate: datasource=github-releases depName=CloudCannon/pagefind
 const Version = "1.4.0"
 
-// Install ensures pagefind (extended) is available.
+// Install ensures pagefind is available.
 var Install = &pk.Task{
 	Name:   "install:pagefind",
 	Usage:  "install pagefind",
@@ -34,7 +34,7 @@ func installPagefind() pk.Runnable {
 	binaryPath := filepath.Join(binDir, binaryName)
 
 	url := fmt.Sprintf(
-		"https://github.com/CloudCannon/pagefind/releases/download/v%s/pagefind_extended-v%s-%s.tar.gz",
+		"https://github.com/CloudCannon/pagefind/releases/download/v%s/pagefind-v%s-%s.tar.gz",
 		Version, Version, platformTarget(),
 	)
 


### PR DESCRIPTION
## Why?

The pagefind tool downloads `pagefind_extended-v*.tar.gz` which contains a binary named `pagefind_extended`. The extraction expects a binary named `pagefind` (matching `Name`), resulting in a broken symlink at `.pocket/bin/pagefind`.

## What?

- Change download URL from `pagefind_extended` to `pagefind` variant
- The non-extended archive contains a binary named `pagefind`, matching the expected `Name` constant