### PR TITLE
feat(pk): add WithVerbose option to force streamed output

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -841,6 +841,16 @@ pk.WithOptions(
 )
 ```
 
+Use `WithVerbose()` to force streamed output for specific tasks, regardless of
+whether the `-v` CLI flag was passed:
+
+```go
+pk.WithOptions(
+    DeployTask,
+    pk.WithVerbose(),  // Always stream output in real-time
+)
+```
+
 ---
 
 ## Options
@@ -857,6 +867,7 @@ pk.WithOptions(
 | `pk.WithNameSuffix(suffix)`          | Add suffix to task names (e.g., `:v2`) |
 | `pk.WithFlags(flagsStruct)`          | Override a task's flags                |
 | `pk.WithForceRun()`                  | Disable deduplication                  |
+| `pk.WithVerbose()`                   | Force verbose (streamed) output        |
 | `pk.WithNoticePatterns(...)`         | Override warning detection patterns    |
 
 Use `pk.WithFlags()` to set task flags explicitly:

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -210,6 +210,7 @@ These options work with any task:
 | `WithDetect`         | Dynamically discover paths using a detection function       |
 | `WithNameSuffix`     | Create a named variant (e.g., `py-test` → `py-test:3.9`)    |
 | `WithForceRun`       | Bypass task deduplication for the wrapped runnable          |
+| `WithVerbose`        | Force verbose (streamed) output regardless of `-v` flag     |
 | `WithFlags`          | Set flag overrides for a task in scope                      |
 | `WithNoticePatterns` | Override warning detection patterns for the scope           |
 
@@ -302,6 +303,13 @@ var InstallUV = &pk.Task{
 
 ```go
 pk.WithOptions(CleanupTask, pk.WithForceRun())
+```
+
+**Force verbose output** with `WithVerbose()` to always stream output in
+real-time, regardless of the `-v` CLI flag:
+
+```go
+pk.WithOptions(DeployTask, pk.WithVerbose())
 ```
 
 ---

--- a/pk/options.go
+++ b/pk/options.go
@@ -122,6 +122,15 @@ func WithNoticePatterns(patterns ...string) Option {
 	}
 }
 
+// WithVerbose forces verbose mode for all tasks within the wrapped Runnable,
+// regardless of whether the -v CLI flag was passed.
+// Useful for manual tasks that always benefit from streamed output.
+func WithVerbose() Option {
+	return func(pf *pathFilter) {
+		pf.verbose = true
+	}
+}
+
 // WithNameSuffix creates a named variant of tasks within this scope.
 // The suffix is appended with a colon separator (e.g., "py-test" becomes "py-test:3.9").
 //
@@ -190,6 +199,7 @@ type pathFilter struct {
 	detectFunc     DetectFunc // Optional detection function for dynamic path discovery.
 	resolvedPaths  []string   // Cached resolved paths from plan building.
 	forceRun       bool       // Disable task deduplication for the wrapped Runnable.
+	verbose        bool       // Force verbose mode for the wrapped Runnable.
 	noticePatterns []string   // Custom notice detection patterns (nil = use default).
 }
 
@@ -214,6 +224,11 @@ func (pf *pathFilter) run(ctx context.Context) error {
 	// If forceRun is set, propagate it to the context.
 	if pf.forceRun {
 		ctx = context.WithValue(ctx, ctxkey.ForceRun{}, true)
+	}
+
+	// If verbose is set, force verbose mode in context.
+	if pf.verbose {
+		ctx = context.WithValue(ctx, ctxkey.Verbose{}, true)
 	}
 
 	// Apply name suffix to context.

--- a/pk/options_test.go
+++ b/pk/options_test.go
@@ -166,6 +166,46 @@ func TestPathFilter_DeduplicationByTaskAndPath(t *testing.T) {
 	}
 }
 
+func TestWithVerbose(t *testing.T) {
+	t.Run("ForcesVerboseTrueInTaskContext", func(t *testing.T) {
+		var gotVerbose bool
+		task := &Task{Name: "verbose-task", Do: func(ctx context.Context) error {
+			gotVerbose = pkrun.Verbose(ctx)
+			return nil
+		}}
+
+		// Outer context has verbose=false (the default, no -v flag).
+		ctx := context.Background()
+
+		pf := WithOptions(task, WithVerbose()).(*pathFilter)
+		pf.resolvedPaths = []string{"."}
+
+		if err := pf.run(ctx); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !gotVerbose {
+			t.Error("expected task to see verbose=true when WithVerbose() is set")
+		}
+	})
+
+	t.Run("DoesNotAffectOuterContext", func(t *testing.T) {
+		task := &Task{Name: "verbose-task2", Do: func(_ context.Context) error { return nil }}
+
+		ctx := context.Background()
+
+		pf := WithOptions(task, WithVerbose()).(*pathFilter)
+		pf.resolvedPaths = []string{"."}
+
+		if err := pf.run(ctx); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Outer context should still have verbose=false.
+		if pkrun.Verbose(ctx) {
+			t.Error("expected outer context to remain verbose=false")
+		}
+	})
+}
+
 func TestDetectByFile(t *testing.T) {
 	// Create a temporary directory structure
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## Why?

Some tasks (e.g. deploy, long-running builds) always benefit from real-time streamed output regardless of the global `-v` flag. Currently there's no way to force verbose mode for specific tasks in the composition tree.

## What?

- Add `WithVerbose()` option that forces verbose mode for all tasks within the wrapped Runnable
- Follows the same context-value pattern as `WithForceRun()`
- Add tests and documentation