### PR TITLE
feat(pk): add WithVerbose option with single propagation path

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -841,8 +841,19 @@ pk.WithOptions(
 )
 ```
 
-Use `WithVerbose()` to force streamed output for specific tasks, regardless of
-whether the `-v` CLI flag was passed:
+Force streamed output for specific tasks, regardless of whether the `-v` CLI
+flag was passed. Set `Verbose: true` directly on the task:
+
+```go
+var Deploy = &pk.Task{
+    Name:    "deploy",
+    Usage:   "deploy application",
+    Verbose: true,  // Always stream output in real-time
+    Do:      func(ctx context.Context) error { ... },
+}
+```
+
+Or use `WithVerbose()` to force it via composition:
 
 ```go
 pk.WithOptions(

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -111,6 +111,7 @@ type Task struct {
     Hidden     bool                           // Hide from CLI listings
     HideHeader bool                           // Suppress ":: taskname" header
     Global     bool                           // Deduplicate by name only, ignoring path
+    Verbose    bool                           // Force verbose (streamed) output
 }
 ```
 
@@ -305,10 +306,14 @@ var InstallUV = &pk.Task{
 pk.WithOptions(CleanupTask, pk.WithForceRun())
 ```
 
-**Force verbose output** with `WithVerbose()` to always stream output in
-real-time, regardless of the `-v` CLI flag:
+**Force verbose output** to always stream output in real-time, regardless of the
+`-v` CLI flag. Set `Verbose: true` on the task, or use `WithVerbose()` in
+composition:
 
 ```go
+var Deploy = &pk.Task{Name: "deploy", Verbose: true, Do: deployFn}
+
+// Or via composition:
 pk.WithOptions(DeployTask, pk.WithVerbose())
 ```
 

--- a/pk/cli.go
+++ b/pk/cli.go
@@ -253,6 +253,11 @@ func (inst *taskInstance) execute(ctx context.Context) error {
 		ctx = contextWithNameSuffix(ctx, suffix)
 	}
 
+	// Apply verbose mode if set during planning (from WithVerbose).
+	if inst.verbose {
+		ctx = context.WithValue(ctx, ctxkey.Verbose{}, true)
+	}
+
 	// Determine execution paths.
 	paths := inst.resolvedPaths
 	if len(paths) == 0 {

--- a/pk/cli.go
+++ b/pk/cli.go
@@ -253,11 +253,6 @@ func (inst *taskInstance) execute(ctx context.Context) error {
 		ctx = contextWithNameSuffix(ctx, suffix)
 	}
 
-	// Apply verbose mode if set during planning (from WithVerbose).
-	if inst.verbose {
-		ctx = context.WithValue(ctx, ctxkey.Verbose{}, true)
-	}
-
 	// Determine execution paths.
 	paths := inst.resolvedPaths
 	if len(paths) == 0 {

--- a/pk/options.go
+++ b/pk/options.go
@@ -226,11 +226,6 @@ func (pf *pathFilter) run(ctx context.Context) error {
 		ctx = context.WithValue(ctx, ctxkey.ForceRun{}, true)
 	}
 
-	// If verbose is set, force verbose mode in context.
-	if pf.verbose {
-		ctx = context.WithValue(ctx, ctxkey.Verbose{}, true)
-	}
-
 	// Apply name suffix to context.
 	if pf.nameSuffix != "" {
 		ctx = contextWithNameSuffix(ctx, pf.nameSuffix)

--- a/pk/options_test.go
+++ b/pk/options_test.go
@@ -167,41 +167,19 @@ func TestPathFilter_DeduplicationByTaskAndPath(t *testing.T) {
 }
 
 func TestWithVerbose(t *testing.T) {
-	t.Run("ForcesVerboseTrueInTaskContext", func(t *testing.T) {
-		var gotVerbose bool
-		task := &Task{Name: "verbose-task", Do: func(ctx context.Context) error {
-			gotVerbose = pkrun.Verbose(ctx)
-			return nil
-		}}
-
-		// Outer context has verbose=false (the default, no -v flag).
-		ctx := context.Background()
-
+	t.Run("SetsVerboseOnPathFilter", func(t *testing.T) {
+		task := &Task{Name: "verbose-task", Do: func(_ context.Context) error { return nil }}
 		pf := WithOptions(task, WithVerbose()).(*pathFilter)
-		pf.resolvedPaths = []string{"."}
-
-		if err := pf.run(ctx); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if !gotVerbose {
-			t.Error("expected task to see verbose=true when WithVerbose() is set")
+		if !pf.verbose {
+			t.Error("expected verbose=true on pathFilter when WithVerbose() is set")
 		}
 	})
 
-	t.Run("DoesNotAffectOuterContext", func(t *testing.T) {
-		task := &Task{Name: "verbose-task2", Do: func(_ context.Context) error { return nil }}
-
-		ctx := context.Background()
-
-		pf := WithOptions(task, WithVerbose()).(*pathFilter)
-		pf.resolvedPaths = []string{"."}
-
-		if err := pf.run(ctx); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		// Outer context should still have verbose=false.
-		if pkrun.Verbose(ctx) {
-			t.Error("expected outer context to remain verbose=false")
+	t.Run("DefaultFalse", func(t *testing.T) {
+		task := &Task{Name: "normal-task", Do: func(_ context.Context) error { return nil }}
+		pf := WithOptions(task).(*pathFilter)
+		if pf.verbose {
+			t.Error("expected verbose=false by default")
 		}
 	})
 }

--- a/pk/plan.go
+++ b/pk/plan.go
@@ -186,6 +186,7 @@ type taskInstance struct {
 	name     string         // Effective name (may include suffix like "py-test:3.9")
 	flags    map[string]any // Pre-merged flag overrides for this task.
 	isManual bool           // Whether task is manual (from Config.Manual).
+	verbose  bool           // Force verbose mode (from WithVerbose).
 
 	// Execution context from path filter.
 	resolvedPaths []string // Directories where this task executes.
@@ -206,6 +207,7 @@ type taskCollector struct {
 	activeSkips      []string         // All skipped tasks in current scope.
 	activeNameSuffix string           // Current name suffix from WithNameSuffix.
 	activeFlags      []flagOverride   // All flag overrides in current scope.
+	activeVerbose    bool             // Force verbose mode in current scope.
 	inManualSection  bool             // True when walking Config.Manual tasks.
 }
 
@@ -374,6 +376,7 @@ func (pc *taskCollector) walk(r Runnable) error {
 				name:          effectiveName,
 				flags:         mergedFlags,
 				isManual:      pc.inManualSection,
+				verbose:       pc.activeVerbose,
 				resolvedPaths: finalPaths,
 			})
 		}
@@ -428,6 +431,7 @@ func (pc *taskCollector) walk(r Runnable) error {
 		prevPath := pc.currentPath
 		prevNameSuffix := pc.activeNameSuffix
 		prevFlags := pc.activeFlags
+		prevVerbose := pc.activeVerbose
 
 		// Resolve type-based flag overrides against the inner runnable.
 		resolvedFlags, err := resolveTypedFlags(v.flags, v.inner)
@@ -441,6 +445,7 @@ func (pc *taskCollector) walk(r Runnable) error {
 		pc.activeSkips = append(pc.activeSkips, v.skippedTasks...)
 		pc.activeFlags = append(pc.activeFlags, resolvedFlags...)
 		pc.currentPath = v
+		pc.activeVerbose = pc.activeVerbose || v.verbose
 
 		// Apply name suffix (cumulative: "3.9" + "foo" -> "3.9:foo").
 		if v.nameSuffix != "" {
@@ -463,6 +468,7 @@ func (pc *taskCollector) walk(r Runnable) error {
 		pc.currentPath = prevPath
 		pc.activeNameSuffix = prevNameSuffix
 		pc.activeFlags = prevFlags
+		pc.activeVerbose = prevVerbose
 
 	default:
 		panic(fmt.Sprintf("pk: unknown Runnable type %T in walk", r))

--- a/pk/plan.go
+++ b/pk/plan.go
@@ -376,7 +376,7 @@ func (pc *taskCollector) walk(r Runnable) error {
 				name:          effectiveName,
 				flags:         mergedFlags,
 				isManual:      pc.inManualSection,
-				verbose:       pc.activeVerbose,
+				verbose:       v.Verbose || pc.activeVerbose,
 				resolvedPaths: finalPaths,
 			})
 		}

--- a/pk/plan_test.go
+++ b/pk/plan_test.go
@@ -992,6 +992,29 @@ func TestPlan_WithVerbosePropagatedToTaskInstance(t *testing.T) {
 	}
 }
 
+func TestPlan_TaskVerbosePropagatedToTaskInstance(t *testing.T) {
+	allDirs := []string{"."}
+
+	task := &Task{Name: "deploy", Usage: "deploy app", Verbose: true, Do: func(_ context.Context) error { return nil }}
+
+	cfg := &Config{
+		Manual: []Runnable{task},
+	}
+
+	plan, err := newPlan(cfg, "/tmp", allDirs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	instance := plan.taskInstanceByName("deploy")
+	if instance == nil {
+		t.Fatal("expected task instance 'deploy' in plan")
+	}
+	if !instance.verbose {
+		t.Error("expected verbose=true on task instance when Task.Verbose is true")
+	}
+}
+
 func TestPlan_WithVerboseNotSetByDefault(t *testing.T) {
 	allDirs := []string{"."}
 

--- a/pk/plan_test.go
+++ b/pk/plan_test.go
@@ -966,3 +966,51 @@ func TestPlan_WithFlagsInferTask(t *testing.T) {
 		t.Errorf("expected mode=overridden, got %v", tasks[0].Flags["mode"])
 	}
 }
+
+func TestPlan_WithVerbosePropagatedToTaskInstance(t *testing.T) {
+	allDirs := []string{"."}
+
+	task := &Task{Name: "serve", Usage: "serve docs", Do: func(_ context.Context) error { return nil }}
+
+	cfg := &Config{
+		Manual: []Runnable{
+			WithOptions(task, WithVerbose()),
+		},
+	}
+
+	plan, err := newPlan(cfg, "/tmp", allDirs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	instance := plan.taskInstanceByName("serve")
+	if instance == nil {
+		t.Fatal("expected task instance 'serve' in plan")
+	}
+	if !instance.verbose {
+		t.Error("expected verbose=true on task instance when WithVerbose() is set")
+	}
+}
+
+func TestPlan_WithVerboseNotSetByDefault(t *testing.T) {
+	allDirs := []string{"."}
+
+	task := &Task{Name: "build", Usage: "build project", Do: func(_ context.Context) error { return nil }}
+
+	cfg := &Config{
+		Manual: []Runnable{task},
+	}
+
+	plan, err := newPlan(cfg, "/tmp", allDirs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	instance := plan.taskInstanceByName("build")
+	if instance == nil {
+		t.Fatal("expected task instance 'build' in plan")
+	}
+	if instance.verbose {
+		t.Error("expected verbose=false on task instance by default")
+	}
+}

--- a/pk/task.go
+++ b/pk/task.go
@@ -54,6 +54,9 @@ type Task struct {
 	// Global makes the task deduplicate by name only, ignoring path.
 	// Use this for install tasks that should only run once regardless of path.
 	Global bool
+	// Verbose forces verbose (streamed) output for this task,
+	// regardless of the -v CLI flag. Can also be set via [WithVerbose].
+	Verbose bool
 
 	// flagSet is the internal FlagSet built from Flags by the engine.
 	flagSet *flag.FlagSet
@@ -82,12 +85,17 @@ func (t *Task) run(ctx context.Context) error {
 		effectiveName = t.Name + ":" + suffix
 	}
 
-	// Check manual status via Plan.
+	// Look up plan-level settings for this task (manual check, verbose, flag overrides).
+	var instance *taskInstance
 	if plan := planFromContext(ctx); plan != nil {
-		if instance := plan.taskInstanceByName(effectiveName); instance != nil {
-			if instance.isManual && isAutoExec(ctx) {
-				return nil
-			}
+		instance = plan.taskInstanceByName(effectiveName)
+	}
+	if instance != nil {
+		if instance.isManual && isAutoExec(ctx) {
+			return nil
+		}
+		if instance.verbose {
+			ctx = context.WithValue(ctx, ctxkey.Verbose{}, true)
 		}
 	}
 
@@ -99,13 +107,9 @@ func (t *Task) run(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("task %q: %w", t.Name, err)
 		}
-		// Apply plan-level overrides (from WithFlag).
-		if plan := planFromContext(ctx); plan != nil {
-			if instance := plan.taskInstanceByName(effectiveName); instance != nil {
-				maps.Copy(resolved, instance.flags)
-			}
+		if instance != nil {
+			maps.Copy(resolved, instance.flags)
 		}
-		// Apply CLI overrides (highest priority).
 		if cliFlags := cliFlagsFromContext(ctx); cliFlags != nil {
 			maps.Copy(resolved, cliFlags)
 		}


### PR DESCRIPTION
## Why?

Tasks like deploy or serve benefit from always streaming output regardless of
the `-v` flag. The initial implementation propagated verbose through three
separate code paths (pathFilter.run, taskInstance.execute, plan builder), making
it fragile and hard to extend.

## What?

- Add `Verbose bool` field to `Task` struct for declarative always-verbose tasks
- Simplify to single propagation path: plan is source of truth, `task.run()` is
  the single consumption point that sets verbose in context
- Remove redundant verbose context propagation from `pathFilter.run()` and
  `taskInstance.execute()`
- Consolidate plan lookups in `task.run()` (manual check, verbose, flags in one
  instance lookup)
- Both `Task.Verbose` and `WithVerbose()` merge into `taskInstance.verbose`