### PR TITLE
fix(pk): scope auto execution from subdirectory shims

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,99 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with
+code in this repository.
+
+## What is Pocket
+
+Pocket is a Go-based composable task runner framework. It replaces Makefiles and
+shell scripts with type-safe Go configuration that handles task composition,
+tool installation, and cross-platform execution. The `./pok` shim bootstraps
+everything—no pre-installed dependencies beyond a shell.
+
+## Commands
+
+```bash
+./pok                    # run all auto tasks (lint, test, format, etc.)
+./pok -v                 # verbose mode (streams output in real-time)
+./pok go-test            # run a specific task
+./pok go-test -race      # run a specific task with flags
+./pok go-lint            # run golangci-lint
+./pok plan               # show execution plan without running
+./pok -h                 # list all available tasks
+```
+
+Run Go tests directly (useful during development):
+
+```bash
+go test ./pk/...                      # test the core engine
+go test ./pk/download/...             # test download/extract
+go test ./pk/conventionalcommits/...  # test commit validation
+go test -run TestName ./pk/...        # run a single test
+```
+
+## Architecture
+
+### Core packages
+
+- **`pk/`** — The public API and engine. Contains `Config`, `Task`, `Runnable`,
+  composition (`Serial`, `Parallel`, `WithOptions`), plan building, CLI, output
+  buffering, and task execution. This is the main package users import.
+- **`pk/run/`** — Runtime helpers for task authors: `Exec` (run external
+  commands), `GetFlags` (retrieve typed flags from context), context accessors
+  (`PathFromContext`, `Verbose`, `PlanFromContext`), and output functions
+  (`Printf`, `Println`, `Errorf`).
+- **`pk/download/`** — Download, extract (tar.gz, zip, gz), and symlink API for
+  tool installation.
+- **`pk/platform/`** — OS/arch detection and naming helpers (`HostOS`,
+  `HostArch`, `ArchToX8664`, etc.).
+- **`pk/repopath/`** — Git root detection.
+- **`pk/conventionalcommits/`** — Commit message validation.
+
+### Tool packages (`tools/`)
+
+Each tool package owns its complete lifecycle: installation, versioning, and
+making itself available. Three patterns exist:
+
+1. **Symlink** (native binaries) — download, extract, symlink to `.pocket/bin/`,
+   invoke via `run.Exec(ctx, "tool", ...)`
+2. **Tool Exec** (runtime-dependent) — package exposes `Exec()` function, no
+   symlink
+3. **Runtime Run** (project-managed) — use runtime's `Run()` directly (e.g.,
+   `uv.Run`)
+
+### Task packages (`tasks/`)
+
+Pre-built opinionated tasks that wrap tools: `golang`, `python`, `markdown`,
+`github`, `lua`, `treesitter`, `docs`, `claude`. Each exposes a `Tasks()`
+function returning composed runnables, plus individual task variables.
+
+### Execution model
+
+1. User's `.pocket/config.go` defines a `Config` with `Auto` (composition tree)
+   and `Manual` tasks
+2. Plan builder walks the composition tree, resolves paths (via
+   `WithDetect`/`WithPath`), and creates task instances
+3. Executor runs the plan: `Serial` = sequential (stop on error), `Parallel` =
+   concurrent with buffered output
+4. Generated subdirectory shims set `TASK_SCOPE`, causing bare `./pok` and
+   direct task execution to run only tasks relevant to that shim path
+5. Same task at same path is deduplicated; `Global: true` tasks deduplicate
+   across all paths
+
+### Key files in this repo's own config
+
+- `.pocket/config.go` — This project's Pocket configuration (uses
+  `golang.Tasks()`, `markdown.Format`, `github.Tasks()`)
+- `.pocket/main.go` — Entry point that calls `pk.RunMain(Config)`
+- `cmd/pocket/main.go` — The `pocket init` bootstrapper CLI
+
+## Conventions
+
+- The `pk` package re-exports platform helpers from `pk/platform/` for
+  convenience (e.g., `pk.HostOS()` delegates to `platform.HostOS()`)
+- Install tasks use `Hidden: true` (internal detail) and `Global: true` (run
+  once regardless of path)
+- Task flags are structs with `flag` and `usage` tags, accessed via
+  `run.GetFlags[T](ctx)`
+- Pointer flag fields (`*bool`, `*string`) mean "not set" when nil — used with
+  `pk.WithFlags` for selective overrides

--- a/.claude/skills/pocket-engine/INTERNALS.md
+++ b/.claude/skills/pocket-engine/INTERNALS.md
@@ -278,8 +278,10 @@ Each shim sets:
 ### Task visibility scoping
 
 When `TASK_SCOPE` is set (by a subdirectory shim), only tasks whose resolved
-paths include that scope appear in help and are eligible for execution. Root
-shims set `TASK_SCOPE="."`, making all tasks visible.
+paths include that scope appear in help and are eligible for execution. Bare
+`./pok` auto execution is also narrowed to that scope, and direct task
+invocation runs the task only for that scope. Root shims set `TASK_SCOPE="."`,
+making all tasks visible and executable across all resolved paths.
 
 ---
 

--- a/.claude/skills/pocket-engine/SKILL.md
+++ b/.claude/skills/pocket-engine/SKILL.md
@@ -116,6 +116,6 @@ first-to-complete ordering. Single-item parallel runs skip buffering entirely.
 Shims are generated at the repo root and at each unique include/detect path.
 Three variants: POSIX (`pok`), Windows batch (`pok.cmd`), PowerShell
 (`pok.ps1`). Each shim computes a relative path back to `.pocket` and sets
-`TASK_SCOPE` for path-scoped task visibility.
+`TASK_SCOPE` for path-scoped task visibility and execution.
 
 See [INTERNALS.md](INTERNALS.md) for details on each subsystem.

--- a/README.md
+++ b/README.md
@@ -212,7 +212,8 @@ bypass deduplication when needed.
 
 Pocket generates shims in each detected module directory (`pk.WithDetect`) and
 each path defined with `pk.WithPath`. The root shim runs everything, while
-subfolder shims only run tasks scoped to that path:
+subfolder shims set `TASK_SCOPE` so both bare `./pok` and direct task invocation
+only run work relevant to that path:
 
 ```bash
 ./pok                       # runs all tasks across all paths

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -999,11 +999,15 @@ Pocket generates `./pok` shims in directories matched by `WithPath` or
 `WithDetect`.
 
 - Running `./pok` from **root** shows and executes all tasks
-- Running `./pok` from a **subdirectory** only shows tasks scoped to that path
+- Running `./pok` from a **subdirectory** only shows and executes tasks scoped
+  to that path
+- Running `./pok <task>` from a **subdirectory** executes that task only for the
+  shim's path
 
 ```bash
 ./pok                       # runs all tasks across all paths
 cd services/api && ./pok    # only runs tasks scoped to services/api
+./pok go-test               # runs go-test only in services/api
 ```
 
 ---

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -62,6 +62,24 @@ type ShimConfig struct {
 | :--------------- | :------------------------------------ |
 | `AllShimsConfig` | Returns config with all shims enabled |
 
+### Shim Scoping
+
+Pocket generates shims at the repository root and at path scopes derived from
+`WithPath` and `WithDetect`. Root shims set `TASK_SCOPE="."`, so bare `./pok`
+shows and executes the full auto task tree across all resolved paths.
+
+Subdirectory shims set `TASK_SCOPE` to the shim's path. In that mode:
+
+- Bare `./pok` shows and executes only tasks scoped to that path
+- `./pok <task>` executes the named task only for that path
+- Root-only tasks are hidden and skipped from subdirectory shims
+
+```bash
+./pok                       # root: run all auto tasks across all paths
+cd services/api && ./pok    # scoped: run only services/api tasks
+./pok go-test               # scoped: run go-test only in services/api
+```
+
 ### Git Diff Check
 
 Pocket can run `git diff --exit-code` after task execution to catch unintended

--- a/pk/builtins.go
+++ b/pk/builtins.go
@@ -211,7 +211,6 @@ var commitsCheckTask = &Task{
 func resolveCommitRange(ctx context.Context) (string, error) {
 	gitRoot := repopath.GitRoot()
 
-	//nolint:gosec // Arguments are fixed git commands, not user-supplied.
 	cmd := exec.CommandContext(ctx, "git", "log", "--oneline", "@{push}..HEAD")
 	cmd.Dir = gitRoot
 	var out bytes.Buffer
@@ -230,7 +229,6 @@ func resolveCommitRange(ctx context.Context) (string, error) {
 	}
 
 	ref := "origin/" + defaultBranch + "..HEAD"
-	//nolint:gosec // ref is constructed from git output, not user input.
 	cmd = exec.CommandContext(ctx, "git", "log", "--oneline", ref)
 	cmd.Dir = gitRoot
 	out.Reset()
@@ -244,7 +242,6 @@ func resolveCommitRange(ctx context.Context) (string, error) {
 
 // resolveDefaultBranch returns the default branch name of the origin remote.
 func resolveDefaultBranch(ctx context.Context, gitRoot string) string {
-	//nolint:gosec // Arguments are fixed git commands, not user-supplied.
 	cmd := exec.CommandContext(ctx, "git", "symbolic-ref", "refs/remotes/origin/HEAD")
 	cmd.Dir = gitRoot
 	var out bytes.Buffer

--- a/pk/cli.go
+++ b/pk/cli.go
@@ -260,7 +260,7 @@ func (inst *taskInstance) execute(ctx context.Context) error {
 	}
 
 	// Check TASK_SCOPE environment variable (set by shim).
-	if taskScope := os.Getenv("TASK_SCOPE"); taskScope != "" && taskScope != "." {
+	if taskScope := taskScopeFromEnv(); taskScope != "" {
 		paths = []string{taskScope}
 	}
 

--- a/pk/context_internal.go
+++ b/pk/context_internal.go
@@ -2,6 +2,7 @@ package pk
 
 import (
 	"context"
+	"os"
 
 	"github.com/fredrikaverpil/pocket/pk/internal/ctxkey"
 )
@@ -46,4 +47,12 @@ func cliFlagsFromContext(ctx context.Context) map[string]any {
 		return flags
 	}
 	return nil
+}
+
+func taskScopeFromEnv() string {
+	scope := os.Getenv("TASK_SCOPE")
+	if scope == "" || scope == "." {
+		return ""
+	}
+	return scope
 }

--- a/pk/e2e_test.go
+++ b/pk/e2e_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fredrikaverpil/pocket/pk/internal/ctxkey"
 	"github.com/fredrikaverpil/pocket/pk/repopath"
 	pkrun "github.com/fredrikaverpil/pocket/pk/run"
+	"gotest.tools/v3/assert"
 )
 
 // Flag struct types for test tasks.
@@ -560,4 +561,40 @@ func TestE2E_AutoExec_PathFilterWithDetect(t *testing.T) {
 	if !paths["svc-a"] || !paths["svc-b"] {
 		t.Errorf("expected paths svc-a and svc-b, got %v", paths)
 	}
+}
+
+func TestE2E_AutoExec_TaskScope(t *testing.T) {
+	tmpDir := e2eSetup(t)
+
+	for _, d := range []string{"svc-a", "svc-b"} {
+		if err := os.MkdirAll(filepath.Join(tmpDir, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	rec := newRecorder()
+	rootTask := rec.task("root")
+	scopedTask := rec.task("scoped")
+
+	cfg := &Config{
+		Auto: Serial(
+			rootTask,
+			WithOptions(scopedTask, WithPath("svc-a", "svc-b")),
+		),
+	}
+	plan, err := newPublicPlan(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("TASK_SCOPE", "svc-a")
+
+	ctx := e2eCtx(t, plan)
+	ctx = context.WithValue(ctx, ctxkey.AutoExec{}, true)
+	if err := cfg.Auto.run(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []execRecord{{TaskName: "scoped", Path: "svc-a"}}
+	assert.DeepEqual(t, rec.records, want)
 }

--- a/pk/options.go
+++ b/pk/options.go
@@ -236,8 +236,19 @@ func (pf *pathFilter) run(ctx context.Context) error {
 		ctx = context.WithValue(ctx, ctxkey.NoticePatterns{}, pf.noticePatterns)
 	}
 
+	paths := pf.resolvedPaths
+	if taskScope := taskScopeFromEnv(); isAutoExec(ctx) && taskScope != "" {
+		paths = nil
+		for _, path := range pf.resolvedPaths {
+			if path == taskScope {
+				paths = []string{path}
+				break
+			}
+		}
+	}
+
 	// Execute inner Runnable for each resolved path.
-	for _, path := range pf.resolvedPaths {
+	for _, path := range paths {
 		pathCtx := pkrun.ContextWithPath(ctx, path)
 		if err := pf.inner.run(pathCtx); err != nil {
 			return err

--- a/pk/task.go
+++ b/pk/task.go
@@ -87,7 +87,8 @@ func (t *Task) run(ctx context.Context) error {
 
 	// Look up plan-level settings for this task (manual check, verbose, flag overrides).
 	var instance *taskInstance
-	if plan := planFromContext(ctx); plan != nil {
+	plan := planFromContext(ctx)
+	if plan != nil {
 		instance = plan.taskInstanceByName(effectiveName)
 	}
 	if instance != nil {
@@ -96,6 +97,11 @@ func (t *Task) run(ctx context.Context) error {
 		}
 		if instance.verbose {
 			ctx = context.WithValue(ctx, ctxkey.Verbose{}, true)
+		}
+	}
+	if taskScope := taskScopeFromEnv(); isAutoExec(ctx) && taskScope != "" && plan != nil {
+		if !plan.taskRunsInPath(effectiveName, taskScope) {
+			return nil
 		}
 	}
 
@@ -134,7 +140,7 @@ func (t *Task) run(ctx context.Context) error {
 
 	// Check if this task should run at this path based on the Plan's pathMappings.
 	// This handles task-specific excludes (WithSkipTask with patterns).
-	if plan := planFromContext(ctx); plan != nil {
+	if plan != nil {
 		if info, ok := plan.pathMappings[effectiveName]; ok {
 			path := pkrun.PathFromContext(ctx)
 			if !slices.Contains(info.resolvedPaths, path) {


### PR DESCRIPTION
## Why?

Subdirectory `pok` shims set `TASK_SCOPE`, but bare `./pok` still executed the full auto task tree across all resolved paths. This made scoped shims behave differently from their intended folder-local workflow.

## What?

- Scope auto path-filter execution to the shim path when `TASK_SCOPE` is set
- Skip root-only and unrelated tasks during scoped auto execution
- Reuse normalized `TASK_SCOPE` handling for direct task execution
- Add e2e coverage for scoped bare `./pok`
- Update README, guides, reference docs, and engine notes for scoped shim behavior

## Notes

Verified with `./pok md-format` and `go test ./...`.