### PR TITLE
ci: skip cache save after exact hit

### DIFF
--- a/.github/workflows/pocket-pertask.yml
+++ b/.github/workflows/pocket-pertask.yml
@@ -28,6 +28,7 @@ jobs:
           go-version-file: .pocket/go.mod
           cache: false
       - name: Restore cache
+        id: cache-restore
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -45,7 +46,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: ./pok -v -g -c go-fix
       - name: Save cache
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && steps.cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: |
@@ -67,6 +68,7 @@ jobs:
           go-version-file: .pocket/go.mod
           cache: false
       - name: Restore cache
+        id: cache-restore
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -84,7 +86,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: ./pok -v -g -c go-fix
       - name: Save cache
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && steps.cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: |
@@ -106,6 +108,7 @@ jobs:
           go-version-file: .pocket/go.mod
           cache: false
       - name: Restore cache
+        id: cache-restore
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -123,7 +126,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: .\pok.ps1 -v -g -c go-fix
       - name: Save cache
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && steps.cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: |
@@ -145,6 +148,7 @@ jobs:
           go-version-file: .pocket/go.mod
           cache: false
       - name: Restore cache
+        id: cache-restore
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -162,7 +166,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: ./pok -v -g -c go-format
       - name: Save cache
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && steps.cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: |
@@ -184,6 +188,7 @@ jobs:
           go-version-file: .pocket/go.mod
           cache: false
       - name: Restore cache
+        id: cache-restore
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -201,7 +206,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: ./pok -v -g -c go-format
       - name: Save cache
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && steps.cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: |
@@ -223,6 +228,7 @@ jobs:
           go-version-file: .pocket/go.mod
           cache: false
       - name: Restore cache
+        id: cache-restore
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -240,7 +246,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: .\pok.ps1 -v -g -c go-format
       - name: Save cache
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && steps.cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: |
@@ -262,6 +268,7 @@ jobs:
           go-version-file: .pocket/go.mod
           cache: false
       - name: Restore cache
+        id: cache-restore
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -279,7 +286,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: ./pok -v -g -c go-lint
       - name: Save cache
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && steps.cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: |
@@ -301,6 +308,7 @@ jobs:
           go-version-file: .pocket/go.mod
           cache: false
       - name: Restore cache
+        id: cache-restore
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -318,7 +326,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: ./pok -v -g -c go-lint
       - name: Save cache
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && steps.cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: |
@@ -340,6 +348,7 @@ jobs:
           go-version-file: .pocket/go.mod
           cache: false
       - name: Restore cache
+        id: cache-restore
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -357,7 +366,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: .\pok.ps1 -v -g -c go-lint
       - name: Save cache
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && steps.cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: |
@@ -379,6 +388,7 @@ jobs:
           go-version-file: .pocket/go.mod
           cache: false
       - name: Restore cache
+        id: cache-restore
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -396,7 +406,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: ./pok -v -g -c go-test
       - name: Save cache
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && steps.cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: |
@@ -418,6 +428,7 @@ jobs:
           go-version-file: .pocket/go.mod
           cache: false
       - name: Restore cache
+        id: cache-restore
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -435,7 +446,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: ./pok -v -g -c go-test
       - name: Save cache
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && steps.cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: |
@@ -457,6 +468,7 @@ jobs:
           go-version-file: .pocket/go.mod
           cache: false
       - name: Restore cache
+        id: cache-restore
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -474,7 +486,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: .\pok.ps1 -v -g -c go-test
       - name: Save cache
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && steps.cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: |
@@ -496,6 +508,7 @@ jobs:
           go-version-file: .pocket/go.mod
           cache: false
       - name: Restore cache
+        id: cache-restore
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -513,7 +526,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: ./pok -v -g -c go-vulncheck
       - name: Save cache
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && steps.cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: |
@@ -535,6 +548,7 @@ jobs:
           go-version-file: .pocket/go.mod
           cache: false
       - name: Restore cache
+        id: cache-restore
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -552,7 +566,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: ./pok -v -g -c go-vulncheck
       - name: Save cache
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && steps.cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: |
@@ -574,6 +588,7 @@ jobs:
           go-version-file: .pocket/go.mod
           cache: false
       - name: Restore cache
+        id: cache-restore
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -591,7 +606,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: .\pok.ps1 -v -g -c go-vulncheck
       - name: Save cache
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && steps.cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: |
@@ -613,6 +628,7 @@ jobs:
           go-version-file: .pocket/go.mod
           cache: false
       - name: Restore cache
+        id: cache-restore
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -630,7 +646,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: ./pok -v -g -c md-format
       - name: Save cache
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && steps.cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: |
@@ -652,6 +668,7 @@ jobs:
           go-version-file: .pocket/go.mod
           cache: false
       - name: Restore cache
+        id: cache-restore
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -669,7 +686,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: ./pok -v -g -c md-format
       - name: Save cache
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && steps.cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: |
@@ -691,6 +708,7 @@ jobs:
           go-version-file: .pocket/go.mod
           cache: false
       - name: Restore cache
+        id: cache-restore
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -708,7 +726,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: .\pok.ps1 -v -g -c md-format
       - name: Save cache
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && steps.cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: |
@@ -730,6 +748,7 @@ jobs:
           go-version-file: .pocket/go.mod
           cache: false
       - name: Restore cache
+        id: cache-restore
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -747,7 +766,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: ./pok -v -g -c renovate-validate
       - name: Save cache
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && steps.cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: |
@@ -769,6 +788,7 @@ jobs:
           go-version-file: .pocket/go.mod
           cache: false
       - name: Restore cache
+        id: cache-restore
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -786,7 +806,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: ./pok -v -g -c github-workflows
       - name: Save cache
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && steps.cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: |
@@ -808,6 +828,7 @@ jobs:
           go-version-file: .pocket/go.mod
           cache: false
       - name: Restore cache
+        id: cache-restore
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -825,7 +846,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: ./pok -v -g -c github-workflows
       - name: Save cache
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && steps.cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: |
@@ -847,6 +868,7 @@ jobs:
           go-version-file: .pocket/go.mod
           cache: false
       - name: Restore cache
+        id: cache-restore
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -864,7 +886,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: .\pok.ps1 -v -g -c github-workflows
       - name: Save cache
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && steps.cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: |

--- a/tasks/github/workflows/pocket-pertask.yml.tmpl
+++ b/tasks/github/workflows/pocket-pertask.yml.tmpl
@@ -29,6 +29,7 @@ jobs:
           go-version-file: .pocket/go.mod
           cache: false
       - name: Restore cache
+        id: cache-restore
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -46,7 +47,7 @@ jobs:
           GITHUB_TOKEN: {{`${{ github.token }}`}}
         run: {{ .Shim }} -v{{ if .GitDiff }} -g{{ end }}{{ if .CommitsCheck }} -c{{ end }} {{ .Task }}
       - name: Save cache
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && steps.cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: |

--- a/tasks/github/workflows/pocket.yml.tmpl
+++ b/tasks/github/workflows/pocket.yml.tmpl
@@ -27,6 +27,7 @@ jobs:
           go-version-file: .pocket/go.mod
           cache: false
       - name: Restore cache
+        id: cache-restore
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -42,7 +43,7 @@ jobs:
         shell: bash
         run: ./pok -v{{ if .GitDiff }} -g{{ end }}{{ if .CommitsCheck }} -c{{ end }}
       - name: Save cache
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && steps.cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: |


### PR DESCRIPTION
## Why?

GitHub Actions emits `Cache save failed.` warnings when `actions/cache/save` tries to save a cache key that already exists after an exact restore hit.

## What?

- Give Pocket workflow restore-cache steps an id.
- Skip save-cache steps when restore reports `cache-hit == 'true'`.
- Regenerate the repository's per-task Pocket workflow.

## Notes

Verified with `./pok go-test`, `./pok go-format`, and `./pok go-lint`.