### PR TITLE
ci: serialize release workflow runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ on:
       - main
       - master
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write

--- a/tasks/github/workflows/release.yml.tmpl
+++ b/tasks/github/workflows/release.yml.tmpl
@@ -10,6 +10,10 @@ on:
       - main
       - master
 
+concurrency:
+  group: release-{{`${{ github.ref }}`}}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
## Why?

Rapid merges can trigger overlapping Release Please runs that all try to update the same release PR. Serializing the release workflow avoids stale runs racing when the release PR is refreshed.

## What?

- Add branch-scoped concurrency to the generated release workflow
- Keep `cancel-in-progress: false` so release runs queue instead of cancelling in-flight updates
- Regenerate `.github/workflows/release.yml` from the template

## Notes

Verified with `./pok github-workflows`, `./pok go-test`, and `git diff --check`.