### PR TITLE
feat: add -s/--serial flag to force sequential task execution

### DIFF
--- a/pk/cli.go
+++ b/pk/cli.go
@@ -40,9 +40,11 @@ func run(cfg *Config) (*executionTracker, error) {
 	// Parse command-line flags
 	globalFlags := flag.NewFlagSet("pok", flag.ExitOnError)
 
-	var verbose, gitDiff, commitsCheck, showHelp, showVersion bool
+	var verbose, serial, gitDiff, commitsCheck, showHelp, showVersion bool
 	globalFlags.BoolVar(&verbose, "v", false, "verbose mode")
 	globalFlags.BoolVar(&verbose, "verbose", false, "verbose mode")
+	globalFlags.BoolVar(&serial, "s", false, "force serial execution (disables parallelism and output buffering)")
+	globalFlags.BoolVar(&serial, "serial", false, "force serial execution (disables parallelism and output buffering)")
 	globalFlags.BoolVar(&gitDiff, "g", false, "run git diff check after execution")
 	globalFlags.BoolVar(&gitDiff, "gitdiff", false, "run git diff check after execution")
 	globalFlags.BoolVar(&commitsCheck, "c", false, "validate conventional commits after execution")
@@ -60,6 +62,7 @@ func run(cfg *Config) (*executionTracker, error) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	ctx = context.WithValue(ctx, ctxkey.Verbose{}, verbose)
+	ctx = context.WithValue(ctx, ctxkey.Serial{}, serial)
 	ctx = context.WithValue(ctx, ctxkey.GitDiff{}, gitDiff)
 	ctx = context.WithValue(ctx, ctxkey.CommitsCheck{}, commitsCheck)
 	ctx = context.WithValue(ctx, ctxkey.Output{}, pkrun.StdOutput())
@@ -320,7 +323,7 @@ func printHelp(ctx context.Context, _ *Config, plan *Plan) {
 	}
 
 	allNames := []string{
-		"-c, --commits", "-g, --gitdiff", "-h, --help", "-v, --verbose", "--version",
+		"-c, --commits", "-g, --gitdiff", "-h, --help", "-s, --serial", "-v, --verbose", "--version",
 	}
 	for _, t := range builtins {
 		if !t.Hidden {
@@ -346,6 +349,13 @@ func printHelp(ctx context.Context, _ *Config, plan *Plan) {
 	pkrun.Printf(ctx, "  %-*s  %s\n", maxWidth, "-c, --commits", "validate conventional commits after execution")
 	pkrun.Printf(ctx, "  %-*s  %s\n", maxWidth, "-g, --gitdiff", "run git diff check after execution")
 	pkrun.Printf(ctx, "  %-*s  %s\n", maxWidth, "-h, --help", "show help")
+	pkrun.Printf(
+		ctx,
+		"  %-*s  %s\n",
+		maxWidth,
+		"-s, --serial",
+		"force serial execution (disables parallelism and output buffering)",
+	)
 	pkrun.Printf(ctx, "  %-*s  %s\n", maxWidth, "-v, --verbose", "verbose mode")
 	pkrun.Printf(ctx, "  %-*s  %s\n", maxWidth, "--version", "show version")
 

--- a/pk/composition.go
+++ b/pk/composition.go
@@ -64,9 +64,14 @@ func (p *parallel) run(ctx context.Context) error {
 	default:
 	}
 
-	// Single item? Run directly without buffering.
-	if len(p.runnables) == 1 {
-		return p.runnables[0].run(ctx)
+	// Single item or serial mode: run sequentially without buffering.
+	if len(p.runnables) == 1 || serialFromContext(ctx) {
+		for _, r := range p.runnables {
+			if err := r.run(ctx); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 
 	// Multiple items: use errgroup and buffered output.

--- a/pk/composition_test.go
+++ b/pk/composition_test.go
@@ -195,6 +195,51 @@ func TestParallel_OutputBuffering(t *testing.T) {
 	}
 }
 
+func TestParallel_SerialMode_RunsSequentially(t *testing.T) {
+	var order []int
+
+	p := Parallel(
+		Do(func(_ context.Context) error { order = append(order, 1); return nil }),
+		Do(func(_ context.Context) error { order = append(order, 2); return nil }),
+		Do(func(_ context.Context) error { order = append(order, 3); return nil }),
+	)
+
+	ctx := context.WithValue(context.Background(), ctxkey.Serial{}, true)
+	if err := p.run(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []int{1, 2, 3}
+	if len(order) != len(want) {
+		t.Fatalf("expected %v, got %v", want, order)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Errorf("position %d: expected %d, got %d", i, want[i], order[i])
+		}
+	}
+}
+
+func TestParallel_SerialMode_StopsOnError(t *testing.T) {
+	var ran []int
+	errBoom := errors.New("boom")
+
+	p := Parallel(
+		Do(func(_ context.Context) error { ran = append(ran, 1); return nil }),
+		Do(func(_ context.Context) error { ran = append(ran, 2); return errBoom }),
+		Do(func(_ context.Context) error { ran = append(ran, 3); return nil }),
+	)
+
+	ctx := context.WithValue(context.Background(), ctxkey.Serial{}, true)
+	err := p.run(ctx)
+	if !errors.Is(err, errBoom) {
+		t.Errorf("expected errBoom, got %v", err)
+	}
+	if len(ran) != 2 || ran[0] != 1 || ran[1] != 2 {
+		t.Errorf("expected [1 2], got %v", ran)
+	}
+}
+
 func TestParallel_CancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately.

--- a/pk/context_internal.go
+++ b/pk/context_internal.go
@@ -32,6 +32,11 @@ func forceRunFromContext(ctx context.Context) bool {
 	return v
 }
 
+func serialFromContext(ctx context.Context) bool {
+	v, _ := ctx.Value(ctxkey.Serial{}).(bool)
+	return v
+}
+
 func gitDiffEnabled(ctx context.Context) bool {
 	v, _ := ctx.Value(ctxkey.GitDiff{}).(bool)
 	return v

--- a/pk/internal/ctxkey/ctxkey.go
+++ b/pk/internal/ctxkey/ctxkey.go
@@ -5,6 +5,7 @@ type (
 	Path           struct{} // Current execution path.
 	ForceRun       struct{} // Forcing task execution.
 	Verbose        struct{} // Verbose mode.
+	Serial         struct{} // Force serial execution of parallel tasks.
 	GitDiff        struct{} // Git diff enabled flag.
 	CommitsCheck   struct{} // Commits check enabled flag.
 	Env            struct{} // Environment variable overrides.


### PR DESCRIPTION
## Why?

Parallel task execution buffers output per-goroutine and flushes atomically,
which makes it hard to follow real-time progress or debug failures. A serial
mode lets you trade concurrency for live streaming output without changing
the task configuration.

## What?

- Add `-s`/`--serial` global flag to `pok`
- Store the flag in context via a new `ctxkey.Serial` key
- In `Parallel.run()`, check the key and fall through to sequential execution
  (no goroutines, no buffering) when set
- Update help output to list the new flag
- Add two tests: `TestParallel_SerialMode_RunsSequentially` and
  `TestParallel_SerialMode_StopsOnError`