### PR TITLE
fix(self-update): use GOPRIVATE to scope proxy and sum bypass to pocket

### DIFF
--- a/pk/builtins.go
+++ b/pk/builtins.go
@@ -272,10 +272,14 @@ var selfUpdateTask = &Task{
 
 		if pkrun.GetFlags[selfUpdateFlags](ctx).Force {
 			if pkrun.Verbose(ctx) {
-				pkrun.Printf(ctx, "  running: GOPROXY=direct go get github.com/fredrikaverpil/pocket@latest\n")
+				pkrun.Printf(
+					ctx,
+					"  running: GOPROXY=direct GONOSUMDB=github.com/fredrikaverpil/pocket go get github.com/fredrikaverpil/pocket@latest\n",
+				)
 			}
-			ctx := pkrun.ContextWithEnv(ctx, "GOPROXY=direct")
-			if err := pkrun.Exec(ctx, "go", "get", "github.com/fredrikaverpil/pocket@latest"); err != nil {
+			forceCtx := pkrun.ContextWithEnv(ctx, "GOPROXY=direct")
+			forceCtx = pkrun.ContextWithEnv(forceCtx, "GONOSUMDB=github.com/fredrikaverpil/pocket")
+			if err := pkrun.Exec(forceCtx, "go", "get", "github.com/fredrikaverpil/pocket@latest"); err != nil {
 				return fmt.Errorf("updating pocket dependency: %w", err)
 			}
 		} else {

--- a/pk/builtins.go
+++ b/pk/builtins.go
@@ -274,11 +274,10 @@ var selfUpdateTask = &Task{
 			if pkrun.Verbose(ctx) {
 				pkrun.Printf(
 					ctx,
-					"  running: GOPROXY=direct GONOSUMDB=github.com/fredrikaverpil/pocket go get github.com/fredrikaverpil/pocket@latest\n",
+					"  running: GOPRIVATE=github.com/fredrikaverpil/pocket go get github.com/fredrikaverpil/pocket@latest\n",
 				)
 			}
-			forceCtx := pkrun.ContextWithEnv(ctx, "GOPROXY=direct")
-			forceCtx = pkrun.ContextWithEnv(forceCtx, "GONOSUMDB=github.com/fredrikaverpil/pocket")
+			forceCtx := pkrun.ContextWithEnv(ctx, "GOPRIVATE=github.com/fredrikaverpil/pocket")
 			if err := pkrun.Exec(forceCtx, "go", "get", "github.com/fredrikaverpil/pocket@latest"); err != nil {
 				return fmt.Errorf("updating pocket dependency: %w", err)
 			}


### PR DESCRIPTION
## Why?

\`./pok self-update -force\` is meant to bypass the module proxy cache to
guarantee fetching the latest version. The original implementation set
\`GOPROXY=direct\`, but that bypasses the proxy for *all* modules resolved
in the command, not just pocket. Additionally, Go still verifies the
module via \`sum.golang.org\`, which fetches from GitHub for versions not
yet indexed — causing a 404/connection error for freshly-released versions.

## What?

Replace \`GOPROXY=direct\` + \`GONOSUMDB=...\` with a single
\`GOPRIVATE=github.com/fredrikaverpil/pocket\`, which sets both \`GONOPROXY\`
and \`GONOSUMDB\` scoped to just the pocket module path. This means only
pocket itself bypasses the proxy and sum check — transitive dependencies
are unaffected. Collapses two \`ContextWithEnv\` calls into one.