### PR TITLE
fix(renovate): use fix semantic commit type for custom regex deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,10 @@
       "groupName": "github-actions"
     },
     {
+      "matchManagers": ["custom.regex"],
+      "semanticCommitType": "fix"
+    },
+    {
       "matchManagers": ["gomod"],
       "matchDepNames": ["github.com/fredrikaverpil/pocket"],
       "enabled": false,

--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,13 @@
     },
     {
       "matchManagers": ["custom.regex"],
+      "matchUpdateTypes": ["patch"],
       "semanticCommitType": "fix"
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchUpdateTypes": ["minor", "major"],
+      "semanticCommitType": "feat"
     },
     {
       "matchManagers": ["gomod"],


### PR DESCRIPTION
## Why?

Tools managed via the custom regex manager (e.g. `golangci-lint`, `uv`, `skill-validator`) were getting `chore(deps):` commit prefixes, which release-please ignores. Since these are tool versions Pocket ships to users, updating them is a user-facing change and should trigger a release.

## What?

- Add `packageRules` in `renovate.json` mapping update type to semantic commit type for the `custom.regex` manager:
  - patch → `fix(deps):` → patch release
  - minor/major → `feat(deps):` → minor release