### PR TITLE
feat(pk): add JSON-driven task execution for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,8 +268,9 @@ echo '{"version":1,"tree":{"type":"serial","children":[
 The same engine drives both paths — composition, deduplication, and output
 buffering behave identically. Inspect an existing project's executable task tree
 as JSON with `./pok -json [task]`, and print the v1 schema with
-`./pok exec --schema`. See the [JSON Execution](./docs/reference.md#json-execution)
-reference for full schema and rules.
+`./pok exec --schema`. See the
+[JSON Execution](./docs/reference.md#json-execution) reference for full schema
+and rules.
 
 ### Programmatic Plan Access
 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,13 @@ Pocket provides a built-in `plan` command to visualize your execution tree:
 ./pok plan
 ```
 
+It can also visualize executable JSON trees without running them:
+
+```bash
+./pok -json go-test | ./pok plan
+./pok plan tree.json
+```
+
 ## JSON Execution (for agents)
 
 Pocket can also be driven from a JSON document, primarily for LLMs and agents

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Global flags:
   -c, --commits     validate conventional commits after execution
   -g, --gitdiff     run git diff check after execution
   -h, --help        show help
+  --json            emit task plan as JSON instead of executing
+  -s, --serial      force serial execution (disables parallelism and output buffering)
   -v, --verbose     verbose mode
   --version         show version
 
@@ -62,6 +64,7 @@ Manual tasks:
 Builtin tasks:
   shims             regenerate shims in all directories
   plan              show execution plan without running tasks
+  exec              execute a JSON task tree read from stdin
   self-update       update Pocket and regenerate scaffolded files
   purge             remove .pocket/tools, .pocket/bin, and .pocket/venvs
 
@@ -240,6 +243,24 @@ Pocket provides a built-in `plan` command to visualize your execution tree:
 ```bash
 ./pok plan
 ```
+
+## JSON Execution (for agents)
+
+Pocket can also be driven from a JSON document, primarily for LLMs and agents
+that compose task trees on-the-fly without writing Go code:
+
+```bash
+echo '{"version":1,"tree":{"serial":[
+  {"name":"lint","exec":["golangci-lint","run","./..."]},
+  {"name":"test","exec":["go","test","./..."]}
+]}}' | ./pok exec
+```
+
+The same engine drives both paths — composition, deduplication, and output
+buffering behave identically. Inspect an existing project's plan as JSON with
+`./pok -json [task]`, and print the v1 schema with `./pok exec --schema`. See
+the [JSON Execution](./docs/reference.md#json-execution) reference for full
+schema and rules.
 
 ### Programmatic Plan Access
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ provider. Your CI becomes portable.
   CI matrices, documentation, or custom tooling. Your tasks become the single
   source of truth.
 - **LLM-Friendly**: Emit executable task trees and global execution options as
-  JSON, e.g. `./pok -json -g go-test | ./pok exec` or `./pok exec < tree.json`.
+  JSON, e.g. `./pok --json -g go-test | ./pok exec` or `./pok exec < tree.json`.
 - **Cross-Platform**: Built for macOS, Linux, and Windows.
 
 <details>
@@ -46,7 +46,7 @@ Global flags:
   -c, --commits     validate conventional commits after execution
   -g, --gitdiff     run git diff check after execution
   -h, --help        show help
-  --json            emit task plan as JSON instead of executing
+  -j, --json        emit task plan as JSON instead of executing
   -s, --serial      force serial execution (disables parallelism and output buffering)
   -v, --verbose     verbose mode
   --version         show version
@@ -249,7 +249,7 @@ Pocket provides a built-in `plan` command to visualize your execution tree:
 It can also visualize executable JSON trees without running them:
 
 ```bash
-./pok -json go-test | ./pok plan
+./pok --json go-test | ./pok plan
 ./pok plan tree.json
 ```
 
@@ -267,7 +267,7 @@ echo '{"version":1,"tree":{"type":"serial","children":[
 
 The same engine drives both paths — composition, deduplication, and output
 buffering behave identically. Inspect an existing project's executable task tree
-as JSON with `./pok -json [task]`, and print the v1 schema with
+as JSON with `./pok --json [task]`, and print the v1 schema with
 `./pok exec --schema`. See the
 [JSON Execution](./docs/reference.md#json-execution) reference for full schema
 and rules.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ provider. Your CI becomes portable.
   `./pok plan` before executing, or access the plan programmatically to generate
   CI matrices, documentation, or custom tooling. Your tasks become the single
   source of truth.
+- **LLM-Friendly**: Emit executable task trees as JSON and feed them back into
+  Pocket, e.g. `./pok -json go-test | ./pok exec` or `./pok exec < tree.json`.
 - **Cross-Platform**: Built for macOS, Linux, and Windows.
 
 <details>
@@ -250,17 +252,17 @@ Pocket can also be driven from a JSON document, primarily for LLMs and agents
 that compose task trees on-the-fly without writing Go code:
 
 ```bash
-echo '{"version":1,"tree":{"serial":[
-  {"name":"lint","exec":["golangci-lint","run","./..."]},
-  {"name":"test","exec":["go","test","./..."]}
+echo '{"version":1,"tree":{"type":"serial","children":[
+  {"type":"command","name":"lint","argv":["golangci-lint","run","./..."]},
+  {"type":"command","name":"test","argv":["go","test","./..."]}
 ]}}' | ./pok exec
 ```
 
 The same engine drives both paths — composition, deduplication, and output
-buffering behave identically. Inspect an existing project's plan as JSON with
-`./pok -json [task]`, and print the v1 schema with `./pok exec --schema`. See
-the [JSON Execution](./docs/reference.md#json-execution) reference for full
-schema and rules.
+buffering behave identically. Inspect an existing project's executable task tree
+as JSON with `./pok -json [task]`, and print the v1 schema with
+`./pok exec --schema`. See the [JSON Execution](./docs/reference.md#json-execution)
+reference for full schema and rules.
 
 ### Programmatic Plan Access
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ provider. Your CI becomes portable.
   `./pok plan` before executing, or access the plan programmatically to generate
   CI matrices, documentation, or custom tooling. Your tasks become the single
   source of truth.
-- **LLM-Friendly**: Emit executable task trees as JSON and feed them back into
-  Pocket, e.g. `./pok -json go-test | ./pok exec` or `./pok exec < tree.json`.
+- **LLM-Friendly**: Emit executable task trees and global execution options as
+  JSON, e.g. `./pok -json -g go-test | ./pok exec` or `./pok exec < tree.json`.
 - **Cross-Platform**: Built for macOS, Linux, and Windows.
 
 <details>

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1136,7 +1136,9 @@ Both flags can be combined: `./pok -g -c`.
 ## Plan Introspection
 
 Pocket builds an execution plan before running tasks. This plan is accessible at
-runtime for advanced use cases like CI workflow generation.
+runtime for advanced use cases like CI workflow generation. For human inspection,
+`./pok plan` prints the configured tree, and `./pok plan < tree.json` or
+`./pok plan tree.json` prints a JSON task tree without executing it.
 
 ### Accessing the Plan
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1136,9 +1136,10 @@ Both flags can be combined: `./pok -g -c`.
 ## Plan Introspection
 
 Pocket builds an execution plan before running tasks. This plan is accessible at
-runtime for advanced use cases like CI workflow generation. For human inspection,
-`./pok plan` prints the configured tree, and `./pok plan < tree.json` or
-`./pok plan tree.json` prints a JSON task tree without executing it.
+runtime for advanced use cases like CI workflow generation. For human
+inspection, `./pok plan` prints the configured tree, and
+`./pok plan < tree.json` or `./pok plan tree.json` prints a JSON task tree
+without executing it.
 
 ### Accessing the Plan
 
@@ -1453,5 +1454,5 @@ The global `-json` flag emits the executable task tree of the current
 ```
 
 Because Go-defined task bodies are not shell commands, emitted task nodes use
-`{ "type": "task", "name": "..." }` references rather than raw `argv`
-commands. The output is accepted by `./pok exec` in the same Pocket project.
+`{ "type": "task", "name": "..." }` references rather than raw `argv` commands.
+The output is accepted by `./pok exec` in the same Pocket project.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1367,12 +1367,16 @@ deduplication, the same output buffering, the same global flag behavior.
 
 ### Schema
 
-A versioned root with a single execution tree. Each node has an explicit `type`:
-`task`, `command`, `serial`, or `parallel`. Unknown fields error.
+A versioned root with optional global execution options and a single execution
+tree. Each node has an explicit `type`: `task`, `command`, `serial`, or
+`parallel`. Unknown fields error.
 
 ```json
 {
   "version": 1,
+  "options": {
+    "gitdiff": true
+  },
   "tree": {
     "type": "serial",
     "children": [
@@ -1396,6 +1400,7 @@ A versioned root with a single execution tree. Each node has an explicit `type`:
 }
 ```
 
+`options` mirrors global execution flags such as `-g`, `-s`, `-v`, and `-c`.
 `task` nodes reference existing Pocket tasks by name. `command` nodes run raw
 argument vectors; `argv[0]` is the executable and the rest are arguments. Task
 and command nodes accept an optional `paths` array of literal directories
@@ -1444,6 +1449,7 @@ The global `-json` flag emits the executable task tree of the current
 ```bash
 ./pok -json              # emit the full Auto tree as JSON
 ./pok -json go-test      # emit a single task reference
+./pok -json -g go-test   # include the git-diff post-action as JSON options
 ```
 
 Because Go-defined task bodies are not shell commands, emitted task nodes use

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -49,6 +49,10 @@ defining your first task to building complex CI pipelines.
   - [Simple Workflow](#simple-workflow)
   - [Per-Task Workflow](#per-task-workflow)
   - [PerPocketTaskJobOption](#perpockettaskjoboption)
+- [JSON Execution](#json-execution)
+  - [Schema](#schema)
+  - [Executing JSON](#executing-json)
+  - [Inspecting a Go Project as JSON](#inspecting-a-go-project-as-json)
 
 ---
 
@@ -1348,3 +1352,90 @@ Use `github.AllPlatforms()` to get all platforms (returns `[]Platform`).
 | Parallel task execution          | No        | Yes      |
 | Fail-fast granularity            | All tasks | Per task |
 | Configuration complexity         | Low       | Medium   |
+
+---
+
+## JSON Execution
+
+In addition to the typed `.pocket/config.go` path, Pocket can be driven from a
+JSON document. This is aimed at **LLMs and agents** that need to compose ad-hoc
+task trees without scaffolding a Go project. The JSON path uses the exact same
+engine as the Go config path — same `Serial`/`Parallel` semantics, the same
+deduplication, the same output buffering, the same global flag behavior.
+
+### Schema
+
+A versioned root with a single execution tree. Each node has **exactly one**
+kind key: `exec`, `serial`, or `parallel`. Unknown fields error.
+
+```json
+{
+  "version": 1,
+  "tree": {
+    "serial": [
+      {
+        "name": "lint",
+        "exec": ["golangci-lint", "run", "./..."]
+      },
+      {
+        "parallel": [
+          { "name": "test", "exec": ["go", "test", "./..."] },
+          { "name": "vuln", "exec": ["govulncheck", "./..."] }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Task nodes (those with `exec`) accept an optional `paths` array of literal
+directories relative to the git root. Omit `paths` to run at the repository
+root. See the [JSON Execution](./reference.md#json-execution) reference for the
+full set of validation rules.
+
+### Executing JSON
+
+Pipe a document into the `exec` builtin:
+
+```bash
+echo '{"version":1,"tree":{"exec":["echo","hello"],"name":"greet"}}' \
+  | ./pok exec
+```
+
+Global flags work the same as for any other task:
+
+```bash
+./pok -v exec < tree.json    # stream task output instead of buffering
+./pok -s exec < tree.json    # force serial execution
+./pok -g exec < tree.json    # run git diff check after execution
+```
+
+Validation and parse errors are emitted to stderr as JSON objects, one per
+error, so agents can parse the failure:
+
+```json
+{ "error": "tree.serial[0].name: required for exec nodes" }
+```
+
+The CLI exits non-zero on any validation or execution error.
+
+Print the JSON Schema (Draft-07) for the v1 format with:
+
+```bash
+./pok exec --schema
+```
+
+### Inspecting a Go Project as JSON
+
+The global `-json` flag emits the composition tree of the current
+`.pocket/config.go` project, instead of executing it:
+
+```bash
+./pok -json              # emit the full Auto tree as JSON
+./pok -json go-test      # emit a single-task slice
+```
+
+Emitted task nodes carry `name` and `paths` only — there is no `exec` field,
+because Go-defined task bodies are not shell commands. This is intentionally
+**introspection-only** in v1; the emitted shape is not directly executable
+through `./pok exec`.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1365,22 +1365,28 @@ deduplication, the same output buffering, the same global flag behavior.
 
 ### Schema
 
-A versioned root with a single execution tree. Each node has **exactly one**
-kind key: `exec`, `serial`, or `parallel`. Unknown fields error.
+A versioned root with a single execution tree. Each node has an explicit `type`:
+`task`, `command`, `serial`, or `parallel`. Unknown fields error.
 
 ```json
 {
   "version": 1,
   "tree": {
-    "serial": [
+    "type": "serial",
+    "children": [
       {
-        "name": "lint",
-        "exec": ["golangci-lint", "run", "./..."]
+        "type": "task",
+        "name": "go-format"
       },
       {
-        "parallel": [
-          { "name": "test", "exec": ["go", "test", "./..."] },
-          { "name": "vuln", "exec": ["govulncheck", "./..."] }
+        "type": "parallel",
+        "children": [
+          { "type": "task", "name": "go-test" },
+          {
+            "type": "command",
+            "name": "custom-vet",
+            "argv": ["go", "vet", "./..."]
+          }
         ]
       }
     ]
@@ -1388,17 +1394,20 @@ kind key: `exec`, `serial`, or `parallel`. Unknown fields error.
 }
 ```
 
-Task nodes (those with `exec`) accept an optional `paths` array of literal
-directories relative to the git root. Omit `paths` to run at the repository
-root. See the [JSON Execution](./reference.md#json-execution) reference for the
-full set of validation rules.
+`task` nodes reference existing Pocket tasks by name. `command` nodes run raw
+argument vectors; `argv[0]` is the executable and the rest are arguments. Task
+and command nodes accept an optional `paths` array of literal directories
+relative to the git root. Omit `paths` to use the referenced task's existing
+paths, or the repository root for raw commands. See the
+[JSON Execution](./reference.md#json-execution) reference for the full set of
+validation rules.
 
 ### Executing JSON
 
 Pipe a document into the `exec` builtin:
 
 ```bash
-echo '{"version":1,"tree":{"exec":["echo","hello"],"name":"greet"}}' \
+echo '{"version":1,"tree":{"type":"command","argv":["echo","hello"],"name":"greet"}}' \
   | ./pok exec
 ```
 
@@ -1414,7 +1423,7 @@ Validation and parse errors are emitted to stderr as JSON objects, one per
 error, so agents can parse the failure:
 
 ```json
-{ "error": "tree.serial[0].name: required for exec nodes" }
+{ "error": "tree.children[0].name: required for command nodes" }
 ```
 
 The CLI exits non-zero on any validation or execution error.
@@ -1427,15 +1436,14 @@ Print the JSON Schema (Draft-07) for the v1 format with:
 
 ### Inspecting a Go Project as JSON
 
-The global `-json` flag emits the composition tree of the current
+The global `-json` flag emits the executable task tree of the current
 `.pocket/config.go` project, instead of executing it:
 
 ```bash
 ./pok -json              # emit the full Auto tree as JSON
-./pok -json go-test      # emit a single-task slice
+./pok -json go-test      # emit a single task reference
 ```
 
-Emitted task nodes carry `name` and `paths` only — there is no `exec` field,
-because Go-defined task bodies are not shell commands. This is intentionally
-**introspection-only** in v1; the emitted shape is not directly executable
-through `./pok exec`.
+Because Go-defined task bodies are not shell commands, emitted task nodes use
+`{ "type": "task", "name": "..." }` references rather than raw `argv`
+commands. The output is accepted by `./pok exec` in the same Pocket project.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1444,13 +1444,13 @@ Print the JSON Schema (Draft-07) for the v1 format with:
 
 ### Inspecting a Go Project as JSON
 
-The global `-json` flag emits the executable task tree of the current
+The global `--json` flag emits the executable task tree of the current
 `.pocket/config.go` project, instead of executing it:
 
 ```bash
-./pok -json              # emit the full Auto tree as JSON
-./pok -json go-test      # emit a single task reference
-./pok -json -g go-test   # include the git-diff post-action as JSON options
+./pok --json                 # emit the full Auto tree as JSON
+./pok --json go-test         # emit a single task reference
+./pok --json -g go-test      # include the git-diff post-action as JSON options
 ```
 
 Because Go-defined task bodies are not shell commands, emitted task nodes use

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -678,7 +678,7 @@ if errors.Is(err, pk.ErrGitDiffUncommitted) {
 | `-c`, `--commits` | Validate conventional commits after execution                                                 |
 | `-g`, `--gitdiff` | Run git diff check after execution                                                            |
 | `-h`, `--help`    | Show help                                                                                     |
-| `--json`          | Emit the invocation plan as JSON instead of executing (see [JSON Execution](#json-execution)) |
+| `-j`, `--json`    | Emit the invocation plan as JSON instead of executing (see [JSON Execution](#json-execution)) |
 | `-s`, `--serial`  | Force serial execution (disables parallelism and output buffering)                            |
 | `-v`, `--verbose` | Verbose mode                                                                                  |
 | `--version`       | Show version                                                                                  |
@@ -710,7 +710,7 @@ trees on-the-fly without writing Go code.
 
 Three CLI surfaces share the same schema:
 
-- **`./pok -json [task]`** emits the invocation plan as JSON to stdout (no
+- **`./pok --json [task]`** emits the invocation plan as JSON to stdout (no
   execution). Useful for inspecting an existing Pocket project.
 - **`./pok plan < tree.json`** or **`./pok plan tree.json`** renders a JSON tree
   as the human-readable plan view without executing it.
@@ -826,12 +826,12 @@ other task — they apply through the same context machinery:
 
 ### Inspecting a Go-defined project
 
-The global `-json` flag emits the executable task tree of the current
+The global `--json` flag emits the executable task tree of the current
 `.pocket/config.go` project:
 
 ```bash
-./pok -json              # full Auto tree
-./pok -json go-test      # single task reference
+./pok --json             # full Auto tree
+./pok --json go-test     # single task reference
 ```
 
 Go-defined task bodies are emitted as task references rather than raw commands:
@@ -849,7 +849,7 @@ Go-defined task bodies are emitted as task references rather than raw commands:
 
 The emitted output can be piped back into `./pok exec` in the same Pocket
 project. Global execution flags are serialized as `options`, so
-`./pok -json -g go-test | ./pok exec` preserves the git-diff post-action.
+`./pok --json -g go-test | ./pok exec` preserves the git-diff post-action.
 
 ### Schema document
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -719,21 +719,28 @@ Two CLI surfaces share the same schema:
 ### Schema (v1)
 
 A versioned root with a single execution tree. Strict — unknown fields error.
+Each node has an explicit `type` discriminator.
 
 ```json
 {
   "version": 1,
   "tree": {
-    "serial": [
+    "type": "serial",
+    "children": [
       {
-        "name": "lint",
-        "exec": ["golangci-lint", "run", "./..."],
+        "type": "task",
+        "name": "go-format",
         "paths": ["."]
       },
       {
-        "parallel": [
-          { "name": "test", "exec": ["go", "test", "./..."] },
-          { "name": "vuln", "exec": ["govulncheck", "./..."] }
+        "type": "parallel",
+        "children": [
+          { "type": "task", "name": "go-test" },
+          {
+            "type": "command",
+            "name": "custom-vet",
+            "argv": ["go", "vet", "./..."]
+          }
         ]
       }
     ]
@@ -741,29 +748,39 @@ A versioned root with a single execution tree. Strict — unknown fields error.
 }
 ```
 
-Each node has **exactly one** of these kind keys:
+Node types:
 
-| Kind key   | Type         | Description                                              |
-| :--------- | :----------- | :------------------------------------------------------- |
-| `exec`     | string array | Shell task. Element 0 is the command; the rest are args. |
-| `serial`   | node array   | Sequential composition. Stops on first error.            |
-| `parallel` | node array   | Concurrent composition with buffered output.             |
+| Type       | Required fields      | Description                                             |
+| :--------- | :------------------- | :------------------------------------------------------ |
+| `task`     | `name`               | Reference an existing Pocket task by effective name     |
+| `command`  | `name`, `argv`       | Run a raw command; `argv[0]` is the executable          |
+| `serial`   | `children`           | Sequential composition. Stops on first error            |
+| `parallel` | `children`           | Concurrent composition with buffered output             |
 
-Task-node fields (only valid alongside `exec`):
+Task and command fields:
 
-| Field   | Type         | Required | Description                                                     |
-| :------ | :----------- | :------- | :-------------------------------------------------------------- |
-| `name`  | string       | yes      | Display name used for the `:: task` header and deduplication    |
-| `paths` | string array | no       | Literal directories (relative to git root). Defaults to `["."]` |
+| Field   | Type         | Required | Description                                                               |
+| :------ | :----------- | :------- | :------------------------------------------------------------------------ |
+| `name`  | string       | yes      | Display name for commands; effective Pocket task name for task refs       |
+| `argv`  | string array | command  | Raw argument vector. Only valid on `command` nodes                        |
+| `paths` | string array | no       | Literal directories relative to git root. Defaults to task paths or root  |
+
+Composition fields:
+
+| Field      | Type       | Required | Description                         |
+| :--------- | :--------- | :------- | :---------------------------------- |
+| `children` | node array | yes      | Child nodes for `serial`/`parallel` |
 
 ### Validation rules (strict)
 
 - Unknown top-level or node-level fields error with the field path.
-- A node must have exactly one kind key set; zero or multiple kind keys error.
-- `exec`, `serial`, `parallel`, and `paths` arrays must be non-empty when
-  present (omit `paths` to default to root).
-- `name` is required on `exec` nodes; `name` and `paths` are not allowed on
-  `serial` or `parallel` nodes.
+- Every node must have `type`: `task`, `command`, `serial`, or `parallel`.
+- `command` nodes require non-empty `argv` and `name`.
+- `task` nodes require `name` and must reference a task in the current Pocket
+  project when executed.
+- `serial` and `parallel` nodes require non-empty `children`.
+- `paths` is only valid on `task` and `command` nodes and must be non-empty when
+  present.
 - `version` must be `1`.
 
 ### Errors
@@ -772,7 +789,7 @@ Validation and parse errors are emitted to stderr as JSON, one object per error,
 so they can be parsed by an agent:
 
 ```json
-{ "error": "tree.serial[0].exec: empty array" }
+{ "error": "tree.children[0].argv: empty array" }
 ```
 
 The CLI exits non-zero on any validation or execution error.
@@ -790,19 +807,29 @@ other task — they apply through the same context machinery:
 
 ### Inspecting a Go-defined project
 
-The global `-json` flag emits the composition tree of the current
+The global `-json` flag emits the executable task tree of the current
 `.pocket/config.go` project:
 
 ```bash
 ./pok -json              # full Auto tree
-./pok -json go-test      # single-task slice
+./pok -json go-test      # single task reference
 ```
 
-Emitted task nodes carry `name` and `paths` only — there is no `exec` field,
-because Go-defined task bodies are not introspectable as shell commands.
-Round-trip from `-json` to `exec` is therefore **not** supported in v1; the two
-surfaces share the envelope shape but the emitted form is not directly
-executable.
+Go-defined task bodies are emitted as task references rather than raw commands:
+
+```json
+{
+  "version": 1,
+  "tree": {
+    "type": "task",
+    "name": "go-test",
+    "paths": ["."]
+  }
+}
+```
+
+The emitted output can be piped back into `./pok exec` in the same Pocket
+project.
 
 ### Schema document
 
@@ -814,11 +841,9 @@ Print the JSON Schema (Draft-07) for v1:
 
 ### Out of scope for v1
 
-The following are intentional deferrals; the schema may add new kind keys or
+The following are intentional deferrals; the schema may add new node types or
 fields in later versions:
 
-- **Named task references** (`ref` field): cannot reference Go-defined tasks
-  from JSON yet.
 - **Typed flag overrides** for referenced tasks.
 - **Path detection** (the equivalent of `WithDetect`): paths must be literal.
   Agents are expected to pre-resolve filesystem patterns themselves.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -720,12 +720,17 @@ Three CLI surfaces share the same schema:
 
 ### Schema (v1)
 
-A versioned root with a single execution tree. Strict — unknown fields error.
-Each node has an explicit `type` discriminator.
+A versioned root with optional global execution options and a single execution
+tree. Strict — unknown fields error. Each node has an explicit `type`
+discriminator.
 
 ```json
 {
   "version": 1,
+  "options": {
+    "gitdiff": true,
+    "serial": true
+  },
   "tree": {
     "type": "serial",
     "children": [
@@ -749,6 +754,16 @@ Each node has an explicit `type` discriminator.
   }
 }
 ```
+
+Global options map to Pocket's global CLI flags and are applied when the JSON is
+executed:
+
+| Option    | Equivalent flag    | Description                                                |
+| :-------- | :----------------- | :--------------------------------------------------------- |
+| `verbose` | `-v`, `--verbose`  | Stream command output                                      |
+| `serial`  | `-s`, `--serial`   | Force serial execution                                     |
+| `gitdiff` | `-g`, `--gitdiff`  | Run git diff check after execution                         |
+| `commits` | `-c`, `--commits`  | Validate conventional commits after execution              |
 
 Node types:
 
@@ -783,6 +798,8 @@ Composition fields:
 - `serial` and `parallel` nodes require non-empty `children`.
 - `paths` is only valid on `task` and `command` nodes and must be non-empty when
   present.
+- `options`, when present, may contain `verbose`, `serial`, `gitdiff`, and
+  `commits` booleans.
 - `version` must be `1`.
 
 ### Errors
@@ -831,7 +848,8 @@ Go-defined task bodies are emitted as task references rather than raw commands:
 ```
 
 The emitted output can be piped back into `./pok exec` in the same Pocket
-project.
+project. Global execution flags are serialized as `options`, so
+`./pok -json -g go-test | ./pok exec` preserves the git-diff post-action.
 
 ### Schema document
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -20,6 +20,7 @@ Technical reference for the `github.com/fredrikaverpil/pocket/pk` and
 - [Plan Introspection](#plan-introspection)
 - [Errors](#errors)
 - [CLI](#cli)
+- [JSON Execution](#json-execution)
 
 ---
 
@@ -672,13 +673,15 @@ if errors.Is(err, pk.ErrGitDiffUncommitted) {
 
 ### Flags
 
-| Flag              | Description                                   |
-| :---------------- | :-------------------------------------------- |
-| `-c`, `--commits` | Validate conventional commits after execution |
-| `-g`, `--gitdiff` | Run git diff check after execution            |
-| `-h`, `--help`    | Show help                                     |
-| `-v`, `--verbose` | Verbose mode                                  |
-| `--version`       | Show version                                  |
+| Flag              | Description                                                                                   |
+| :---------------- | :-------------------------------------------------------------------------------------------- |
+| `-c`, `--commits` | Validate conventional commits after execution                                                 |
+| `-g`, `--gitdiff` | Run git diff check after execution                                                            |
+| `-h`, `--help`    | Show help                                                                                     |
+| `--json`          | Emit the invocation plan as JSON instead of executing (see [JSON Execution](#json-execution)) |
+| `-s`, `--serial`  | Force serial execution (disables parallelism and output buffering)                            |
+| `-v`, `--verbose` | Verbose mode                                                                                  |
+| `--version`       | Show version                                                                                  |
 
 ### Functions
 
@@ -696,3 +699,129 @@ func main() {
 // ExecuteTask signature
 func ExecuteTask(ctx context.Context, name string, p *Plan) error
 ```
+
+---
+
+## JSON Execution
+
+Pocket can be driven from a JSON document instead of `.pocket/config.go`. This
+is primarily intended for **LLMs and agents** that need to compose ad-hoc task
+trees on-the-fly without writing Go code.
+
+Two CLI surfaces share the same schema:
+
+- **`./pok -json [task]`** emits the invocation plan as JSON to stdout (no
+  execution). Useful for inspecting an existing Pocket project.
+- **`./pok exec`** reads a JSON document from stdin and executes it through the
+  same engine as the typed-config path (same composition, deduplication, output
+  buffering, and post-actions).
+
+### Schema (v1)
+
+A versioned root with a single execution tree. Strict — unknown fields error.
+
+```json
+{
+  "version": 1,
+  "tree": {
+    "serial": [
+      {
+        "name": "lint",
+        "exec": ["golangci-lint", "run", "./..."],
+        "paths": ["."]
+      },
+      {
+        "parallel": [
+          { "name": "test", "exec": ["go", "test", "./..."] },
+          { "name": "vuln", "exec": ["govulncheck", "./..."] }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Each node has **exactly one** of these kind keys:
+
+| Kind key   | Type         | Description                                              |
+| :--------- | :----------- | :------------------------------------------------------- |
+| `exec`     | string array | Shell task. Element 0 is the command; the rest are args. |
+| `serial`   | node array   | Sequential composition. Stops on first error.            |
+| `parallel` | node array   | Concurrent composition with buffered output.             |
+
+Task-node fields (only valid alongside `exec`):
+
+| Field   | Type         | Required | Description                                                     |
+| :------ | :----------- | :------- | :-------------------------------------------------------------- |
+| `name`  | string       | yes      | Display name used for the `:: task` header and deduplication    |
+| `paths` | string array | no       | Literal directories (relative to git root). Defaults to `["."]` |
+
+### Validation rules (strict)
+
+- Unknown top-level or node-level fields error with the field path.
+- A node must have exactly one kind key set; zero or multiple kind keys error.
+- `exec`, `serial`, `parallel`, and `paths` arrays must be non-empty when
+  present (omit `paths` to default to root).
+- `name` is required on `exec` nodes; `name` and `paths` are not allowed on
+  `serial` or `parallel` nodes.
+- `version` must be `1`.
+
+### Errors
+
+Validation and parse errors are emitted to stderr as JSON, one object per error,
+so they can be parsed by an agent:
+
+```json
+{ "error": "tree.serial[0].exec: empty array" }
+```
+
+The CLI exits non-zero on any validation or execution error.
+
+### Global flags interact normally
+
+`-v`, `-s`, `-g`, and `-c` work with `exec` the same way they work with any
+other task — they apply through the same context machinery:
+
+```bash
+./pok -v exec < tree.json          # stream task output instead of buffering
+./pok -s exec < tree.json          # force serial execution of parallel nodes
+./pok -g exec < tree.json          # run git diff check after execution
+```
+
+### Inspecting a Go-defined project
+
+The global `-json` flag emits the composition tree of the current
+`.pocket/config.go` project:
+
+```bash
+./pok -json              # full Auto tree
+./pok -json go-test      # single-task slice
+```
+
+Emitted task nodes carry `name` and `paths` only — there is no `exec` field,
+because Go-defined task bodies are not introspectable as shell commands.
+Round-trip from `-json` to `exec` is therefore **not** supported in v1; the two
+surfaces share the envelope shape but the emitted form is not directly
+executable.
+
+### Schema document
+
+Print the JSON Schema (Draft-07) for v1:
+
+```bash
+./pok exec --schema
+```
+
+### Out of scope for v1
+
+The following are intentional deferrals; the schema may add new kind keys or
+fields in later versions:
+
+- **Named task references** (`ref` field): cannot reference Go-defined tasks
+  from JSON yet.
+- **Typed flag overrides** for referenced tasks.
+- **Path detection** (the equivalent of `WithDetect`): paths must be literal.
+  Agents are expected to pre-resolve filesystem patterns themselves.
+- **Scope-level options**: `WithForceRun`, `WithVerbose`, `WithNameSuffix`,
+  `WithNoticePatterns`.
+- **File-based input** for `exec`: stdin only.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -758,29 +758,29 @@ discriminator.
 Global options map to Pocket's global CLI flags and are applied when the JSON is
 executed:
 
-| Option    | Equivalent flag    | Description                                                |
-| :-------- | :----------------- | :--------------------------------------------------------- |
-| `verbose` | `-v`, `--verbose`  | Stream command output                                      |
-| `serial`  | `-s`, `--serial`   | Force serial execution                                     |
-| `gitdiff` | `-g`, `--gitdiff`  | Run git diff check after execution                         |
-| `commits` | `-c`, `--commits`  | Validate conventional commits after execution              |
+| Option    | Equivalent flag   | Description                                   |
+| :-------- | :---------------- | :-------------------------------------------- |
+| `verbose` | `-v`, `--verbose` | Stream command output                         |
+| `serial`  | `-s`, `--serial`  | Force serial execution                        |
+| `gitdiff` | `-g`, `--gitdiff` | Run git diff check after execution            |
+| `commits` | `-c`, `--commits` | Validate conventional commits after execution |
 
 Node types:
 
-| Type       | Required fields      | Description                                             |
-| :--------- | :------------------- | :------------------------------------------------------ |
-| `task`     | `name`               | Reference an existing Pocket task by effective name     |
-| `command`  | `name`, `argv`       | Run a raw command; `argv[0]` is the executable          |
-| `serial`   | `children`           | Sequential composition. Stops on first error            |
-| `parallel` | `children`           | Concurrent composition with buffered output             |
+| Type       | Required fields | Description                                         |
+| :--------- | :-------------- | :-------------------------------------------------- |
+| `task`     | `name`          | Reference an existing Pocket task by effective name |
+| `command`  | `name`, `argv`  | Run a raw command; `argv[0]` is the executable      |
+| `serial`   | `children`      | Sequential composition. Stops on first error        |
+| `parallel` | `children`      | Concurrent composition with buffered output         |
 
 Task and command fields:
 
-| Field   | Type         | Required | Description                                                               |
-| :------ | :----------- | :------- | :------------------------------------------------------------------------ |
-| `name`  | string       | yes      | Display name for commands; effective Pocket task name for task refs       |
-| `argv`  | string array | command  | Raw argument vector. Only valid on `command` nodes                        |
-| `paths` | string array | no       | Literal directories relative to git root. Defaults to task paths or root  |
+| Field   | Type         | Required | Description                                                              |
+| :------ | :----------- | :------- | :----------------------------------------------------------------------- |
+| `name`  | string       | yes      | Display name for commands; effective Pocket task name for task refs      |
+| `argv`  | string array | command  | Raw argument vector. Only valid on `command` nodes                       |
+| `paths` | string array | no       | Literal directories relative to git root. Defaults to task paths or root |
 
 Composition fields:
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -708,10 +708,12 @@ Pocket can be driven from a JSON document instead of `.pocket/config.go`. This
 is primarily intended for **LLMs and agents** that need to compose ad-hoc task
 trees on-the-fly without writing Go code.
 
-Two CLI surfaces share the same schema:
+Three CLI surfaces share the same schema:
 
 - **`./pok -json [task]`** emits the invocation plan as JSON to stdout (no
   execution). Useful for inspecting an existing Pocket project.
+- **`./pok plan < tree.json`** or **`./pok plan tree.json`** renders a JSON tree
+  as the human-readable plan view without executing it.
 - **`./pok exec`** reads a JSON document from stdin and executes it through the
   same engine as the typed-config path (same composition, deduplication, output
   buffering, and post-actions).

--- a/pk/builtins.go
+++ b/pk/builtins.go
@@ -28,6 +28,7 @@ var errCommitsInvalid = errors.New("invalid commit messages")
 var builtins = []*Task{
 	shimsTask,
 	planTask,
+	execTask,
 	gitDiffTask,
 	commitsCheckTask,
 	selfUpdateTask,
@@ -128,6 +129,25 @@ var planTask = &Task{
 		pkrun.Printf(ctx, "Legend: [→] = Serial, [⚡] = Parallel\n")
 
 		return nil
+	},
+}
+
+// execFlags defines flags for the exec task.
+type execFlags struct {
+	Schema bool `flag:"schema" usage:"print the JSON Schema document and exit"`
+}
+
+// execTask reads a JSON task document from stdin and executes it.
+var execTask = &Task{
+	Name:       "exec",
+	Usage:      "execute a JSON task tree read from stdin",
+	HideHeader: true,
+	Flags:      execFlags{},
+	Do: func(ctx context.Context) error {
+		if pkrun.GetFlags[execFlags](ctx).Schema {
+			return printExecSchema(ctx)
+		}
+		return runExecJSON(ctx, os.Stdin)
 	},
 }
 

--- a/pk/builtins.go
+++ b/pk/builtins.go
@@ -3,9 +3,9 @@ package pk
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,6 +14,7 @@ import (
 	"github.com/fredrikaverpil/pocket/internal/scaffold"
 	"github.com/fredrikaverpil/pocket/internal/shim"
 	"github.com/fredrikaverpil/pocket/pk/conventionalcommits"
+	"github.com/fredrikaverpil/pocket/pk/internal/ctxkey"
 	"github.com/fredrikaverpil/pocket/pk/repopath"
 	pkrun "github.com/fredrikaverpil/pocket/pk/run"
 )
@@ -85,49 +86,25 @@ var shimsTask = &Task{
 	},
 }
 
-// planFlags defines flags for the plan task.
-type planFlags struct {
-	JSON bool `flag:"json" usage:"output as JSON"`
-}
-
 // planTask displays the execution plan.
 var planTask = &Task{
 	Name:       "plan",
 	Usage:      "show execution plan without running tasks",
 	HideHeader: true,
-	Flags:      planFlags{},
 	Do: func(ctx context.Context) error {
 		p := planFromContext(ctx)
 		if p == nil {
 			return fmt.Errorf("plan not found in context")
 		}
 
-		if pkrun.GetFlags[planFlags](ctx).JSON {
-			return printPlanJSON(ctx, p.tree, p)
+		plan := p
+		if jsonPlan, ok, err := planFromJSONInput(ctx, p); err != nil {
+			return err
+		} else if ok {
+			plan = jsonPlan
 		}
 
-		// Text output.
-		pkrun.Printf(ctx, "Execution Plan\n")
-		pkrun.Printf(ctx, "==============\n\n")
-
-		if len(p.moduleDirectories) > 0 {
-			pkrun.Printf(ctx, "Shim Generation:\n")
-			for _, dir := range p.moduleDirectories {
-				if dir == "." {
-					pkrun.Printf(ctx, "  • root\n")
-				} else {
-					pkrun.Printf(ctx, "  • %s\n", dir)
-				}
-			}
-			pkrun.Println(ctx)
-		}
-
-		pkrun.Printf(ctx, "Composition Tree:\n")
-		printTree(ctx, p.tree, "", true, "", p)
-
-		pkrun.Println(ctx)
-		pkrun.Printf(ctx, "Legend: [→] = Serial, [⚡] = Parallel\n")
-
+		printPlanText(ctx, plan)
 		return nil
 	},
 }
@@ -357,107 +334,79 @@ var purgeTask = &Task{
 
 // --- Plan Helpers ---
 
-// printPlanJSON outputs the plan as JSON.
-func printPlanJSON(ctx context.Context, tree Runnable, p *Plan) error {
-	output := map[string]any{
-		"version":           version(),
-		"moduleDirectories": p.moduleDirectories,
-		"tree":              buildJSONTree(tree, "", p),
-		"tasks":             p.Tasks(),
+// taskArgsFromContext returns positional task args remaining after task flag parsing.
+func taskArgsFromContext(ctx context.Context) []string {
+	if args, ok := ctx.Value(ctxkey.TaskArgs{}).([]string); ok {
+		return args
 	}
-
-	out := pkrun.OutputFromContext(ctx)
-	if out == nil {
-		out = pkrun.StdOutput()
-	}
-	encoder := json.NewEncoder(out.Stdout)
-	encoder.SetIndent("", "  ")
-	return encoder.Encode(output)
+	return nil
 }
 
-// buildJSONTree recursively builds a JSON representation of the composition tree.
-func buildJSONTree(r Runnable, nameSuffix string, p *Plan) map[string]any {
-	if r == nil {
-		return nil
+// planFromJSONInput returns a plan built from JSON supplied by a positional file
+// argument or stdin. The boolean return value is false when no JSON input was supplied.
+func planFromJSONInput(ctx context.Context, basePlan *Plan) (*Plan, bool, error) {
+	args := taskArgsFromContext(ctx)
+	if len(args) > 1 {
+		return nil, false, fmt.Errorf("plan accepts at most one JSON file argument")
 	}
+	if len(args) == 1 {
+		data, err := os.ReadFile(args[0])
+		if err != nil {
+			return nil, false, fmt.Errorf("reading JSON plan %s: %w", args[0], err)
+		}
+		plan, err := buildPlanFromJSONBytes(data, basePlan)
+		return plan, true, err
+	}
+	if pkrun.IsTerminal(os.Stdin) {
+		return nil, false, nil
+	}
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return nil, false, fmt.Errorf("reading JSON plan from stdin: %w", err)
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return nil, false, nil
+	}
+	plan, err := buildPlanFromJSONBytes(data, basePlan)
+	return plan, true, err
+}
 
-	switch v := r.(type) {
-	case *Task:
-		effectiveName := v.Name
-		if nameSuffix != "" {
-			effectiveName = v.Name + ":" + nameSuffix
-		}
+// buildPlanFromJSONBytes parses a JSON task tree and converts it to a Plan.
+func buildPlanFromJSONBytes(data []byte, basePlan *Plan) (*Plan, error) {
+	root, err := parseExecJSON(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	var taskNodes []taskNodeInfo
+	tree, err := buildRunnable(root.Tree, &taskNodes, basePlan)
+	if err != nil {
+		return nil, err
+	}
+	return buildPlanFromJSON(tree, taskNodes, basePlan), nil
+}
 
-		paths := []string{"."}
-		if info, ok := p.pathMappings[effectiveName]; ok {
-			paths = info.resolvedPaths
-		}
+// printPlanText prints the human-readable execution plan.
+func printPlanText(ctx context.Context, p *Plan) {
+	pkrun.Printf(ctx, "Execution Plan\n")
+	pkrun.Printf(ctx, "==============\n\n")
 
-		manual := false
-		if instance := p.taskInstanceByName(effectiveName); instance != nil {
-			manual = instance.isManual
-		}
-
-		return map[string]any{
-			"type":   "task",
-			"name":   effectiveName,
-			"hidden": v.Hidden,
-			"manual": manual,
-			"paths":  paths,
-		}
-
-	case *serial:
-		children := make([]map[string]any, 0, len(v.runnables))
-		for _, child := range v.runnables {
-			if childJSON := buildJSONTree(child, nameSuffix, p); childJSON != nil {
-				children = append(children, childJSON)
-			}
-		}
-		return map[string]any{
-			"type":     "serial",
-			"children": children,
-		}
-
-	case *parallel:
-		children := make([]map[string]any, 0, len(v.runnables))
-		for _, child := range v.runnables {
-			if childJSON := buildJSONTree(child, nameSuffix, p); childJSON != nil {
-				children = append(children, childJSON)
-			}
-		}
-		return map[string]any{
-			"type":     "parallel",
-			"children": children,
-		}
-
-	case *pathFilter:
-		childSuffix := nameSuffix
-		if v.nameSuffix != "" {
-			if nameSuffix != "" {
-				childSuffix = nameSuffix + ":" + v.nameSuffix
+	if len(p.moduleDirectories) > 0 {
+		pkrun.Printf(ctx, "Shim Generation:\n")
+		for _, dir := range p.moduleDirectories {
+			if dir == "." {
+				pkrun.Printf(ctx, "  • root\n")
 			} else {
-				childSuffix = v.nameSuffix
+				pkrun.Printf(ctx, "  • %s\n", dir)
 			}
 		}
-
-		hasPathOptions := len(v.includePaths) > 0 || len(v.excludePaths) > 0 ||
-			v.detectFunc != nil
-		if !hasPathOptions {
-			return buildJSONTree(v.inner, childSuffix, p)
-		}
-
-		node := map[string]any{
-			"type":    "pathFilter",
-			"include": v.includePaths,
-			"exclude": v.excludePaths,
-			"inner":   buildJSONTree(v.inner, childSuffix, p),
-		}
-		return node
+		pkrun.Println(ctx)
 	}
 
-	return map[string]any{
-		"type": "unknown",
-	}
+	pkrun.Printf(ctx, "Composition Tree:\n")
+	printTree(ctx, p.tree, "", true, "", p)
+
+	pkrun.Println(ctx)
+	pkrun.Printf(ctx, "Legend: [→] = Serial, [⚡] = Parallel\n")
 }
 
 // printTree recursively prints the composition tree structure.
@@ -510,6 +459,29 @@ func printTree(
 
 		pkrun.Printf(ctx, "%s%s%s%s\n", prefix, branch, effectiveName, marker)
 
+		continuation := "│   "
+		if isLast {
+			continuation = "    "
+		}
+		pkrun.Printf(ctx, "%s%s    paths: %s\n", prefix, continuation, paths)
+
+	case *jsonTaskRef:
+		markers := []string{"task ref"}
+		if v.task.Hidden {
+			markers = append(markers, "hidden")
+		}
+		if instance := p.taskInstanceByName(v.name); instance != nil && instance.isManual {
+			markers = append(markers, "manual")
+		}
+		paths := "[root]"
+		if info, ok := p.pathMappings[v.name]; ok {
+			if len(info.resolvedPaths) > 0 {
+				paths = formatPaths(info.resolvedPaths)
+			} else {
+				paths = "[skipped]"
+			}
+		}
+		pkrun.Printf(ctx, "%s%s%s [%s]\n", prefix, branch, v.name, strings.Join(markers, ", "))
 		continuation := "│   "
 		if isLast {
 			continuation = "    "

--- a/pk/builtins_test.go
+++ b/pk/builtins_test.go
@@ -116,82 +116,6 @@ func TestFormatPaths(t *testing.T) {
 	}
 }
 
-func TestBuildJSONTree(t *testing.T) {
-	task := &Task{Name: "test", Usage: "test", Do: func(_ context.Context) error { return nil }}
-	_ = task.buildFlagSet()
-
-	plan := &Plan{
-		taskIndex: map[string]*taskInstance{
-			"test": {task: task, name: "test"},
-		},
-		pathMappings: map[string]pathInfo{
-			"test": {resolvedPaths: []string{"."}},
-		},
-	}
-
-	t.Run("SingleTask", func(t *testing.T) {
-		result := buildJSONTree(task, "", plan)
-		if result["type"] != "task" {
-			t.Errorf("expected type=task, got %v", result["type"])
-		}
-		if result["name"] != "test" {
-			t.Errorf("expected name=test, got %v", result["name"])
-		}
-	})
-
-	t.Run("Serial", func(t *testing.T) {
-		s := Serial(task)
-		result := buildJSONTree(s, "", plan)
-		if result["type"] != "serial" {
-			t.Errorf("expected type=serial, got %v", result["type"])
-		}
-		children := result["children"].([]map[string]any)
-		if len(children) != 1 {
-			t.Errorf("expected 1 child, got %d", len(children))
-		}
-	})
-
-	t.Run("Parallel", func(t *testing.T) {
-		p := Parallel(task)
-		result := buildJSONTree(p, "", plan)
-		if result["type"] != "parallel" {
-			t.Errorf("expected type=parallel, got %v", result["type"])
-		}
-	})
-
-	t.Run("Nil", func(t *testing.T) {
-		result := buildJSONTree(nil, "", plan)
-		if result != nil {
-			t.Errorf("expected nil, got %v", result)
-		}
-	})
-
-	t.Run("WithOptions", func(t *testing.T) {
-		pf := WithOptions(task, WithPath("services"))
-		result := buildJSONTree(pf, "", plan)
-		if result["type"] != "pathFilter" {
-			t.Errorf("expected type=pathFilter, got %v", result["type"])
-		}
-		include := result["include"].([]string)
-		if len(include) != 1 || include[0] != "services" {
-			t.Errorf("expected include=[services], got %v", include)
-		}
-	})
-
-	t.Run("WithNameSuffix", func(t *testing.T) {
-		// Update plan to include suffixed task.
-		plan.taskIndex["test:v2"] = &taskInstance{task: task, name: "test:v2"}
-		plan.pathMappings["test:v2"] = pathInfo{resolvedPaths: []string{"."}}
-
-		pf := WithOptions(task, WithNameSuffix("v2"))
-		result := buildJSONTree(pf, "", plan)
-		// No path options, so pathFilter wrapper is omitted; the inner task is returned directly.
-		if result["name"] != "test:v2" {
-			t.Errorf("expected name=test:v2, got %v", result["name"])
-		}
-	})
-}
-
 type lintHelpFlags struct {
 	Fix bool `flag:"fix" usage:"apply fixes"`
 }
@@ -259,28 +183,25 @@ func TestPrintHelp(t *testing.T) {
 	}
 }
 
-func TestPrintPlanJSON(t *testing.T) {
+func TestBuildPlanFromJSONBytes(t *testing.T) {
 	task := &Task{Name: "test", Usage: "test", Do: func(_ context.Context) error { return nil }}
 	_ = task.buildFlagSet()
 	cfg := &Config{Auto: Serial(task)}
-	plan, err := newPlan(cfg, "/tmp", []string{"."})
+	basePlan, err := newPlan(cfg, "/tmp", []string{"."})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	var buf bytes.Buffer
-	out := &pkrun.Output{Stdout: &buf, Stderr: &buf}
-	ctx := context.WithValue(context.Background(), ctxkey.Output{}, out)
-
-	if err := printPlanJSON(ctx, plan.tree, plan); err != nil {
+	data := []byte(`{"version":1,"tree":{"type":"task","name":"test"}}`)
+	plan, err := buildPlanFromJSONBytes(data, basePlan)
+	if err != nil {
 		t.Fatal(err)
 	}
-
-	output := buf.String()
-	for _, want := range []string{`"version"`, `"tree"`, `"tasks"`, `"serial"`, `"test"`} {
-		if !bytes.Contains([]byte(output), []byte(want)) {
-			t.Errorf("expected JSON to contain %q, got:\n%s", want, output)
-		}
+	if plan.tree == nil {
+		t.Fatal("expected JSON plan tree")
+	}
+	if inst := plan.taskInstanceByName("test"); inst == nil {
+		t.Fatal("expected task instance from JSON plan")
 	}
 }
 

--- a/pk/builtins_test.go
+++ b/pk/builtins_test.go
@@ -46,6 +46,7 @@ func TestIsBuiltinName(t *testing.T) {
 	}{
 		{"shims", true},
 		{"plan", true},
+		{"exec", true},
 		{"git-diff", true},
 		{"self-update", true},
 		{"purge", true},

--- a/pk/cli.go
+++ b/pk/cli.go
@@ -40,7 +40,7 @@ func run(cfg *Config) (*executionTracker, error) {
 	// Parse command-line flags
 	globalFlags := flag.NewFlagSet("pok", flag.ExitOnError)
 
-	var verbose, serial, gitDiff, commitsCheck, showHelp, showVersion bool
+	var verbose, serial, gitDiff, commitsCheck, showHelp, showVersion, jsonOut bool
 	globalFlags.BoolVar(&verbose, "v", false, "verbose mode")
 	globalFlags.BoolVar(&verbose, "verbose", false, "verbose mode")
 	globalFlags.BoolVar(&serial, "s", false, "force serial execution (disables parallelism and output buffering)")
@@ -52,6 +52,7 @@ func run(cfg *Config) (*executionTracker, error) {
 	globalFlags.BoolVar(&showHelp, "h", false, "show help")
 	globalFlags.BoolVar(&showHelp, "help", false, "show help")
 	globalFlags.BoolVar(&showVersion, "version", false, "show version")
+	globalFlags.BoolVar(&jsonOut, "json", false, "emit task plan as JSON instead of executing")
 
 	// Parse flags
 	if err := globalFlags.Parse(os.Args[1:]); err != nil {
@@ -88,6 +89,18 @@ func run(cfg *Config) (*executionTracker, error) {
 
 	// Get remaining arguments (task names)
 	remaining := globalFlags.Args()
+
+	// Handle -json: emit instead of executing.
+	if jsonOut {
+		var taskName string
+		if len(remaining) > 0 {
+			taskName = remaining[0]
+		}
+		if err := emitInvocationJSON(plan, taskName, stdoutFromContext(ctx)); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	}
 
 	// Handle task execution (builtins + user tasks)
 	if len(remaining) > 0 {
@@ -323,7 +336,8 @@ func printHelp(ctx context.Context, _ *Config, plan *Plan) {
 	}
 
 	allNames := []string{
-		"-c, --commits", "-g, --gitdiff", "-h, --help", "-s, --serial", "-v, --verbose", "--version",
+		"-c, --commits", "-g, --gitdiff", "-h, --help", "--json",
+		"-s, --serial", "-v, --verbose", "--version",
 	}
 	for _, t := range builtins {
 		if !t.Hidden {
@@ -349,6 +363,7 @@ func printHelp(ctx context.Context, _ *Config, plan *Plan) {
 	pkrun.Printf(ctx, "  %-*s  %s\n", maxWidth, "-c, --commits", "validate conventional commits after execution")
 	pkrun.Printf(ctx, "  %-*s  %s\n", maxWidth, "-g, --gitdiff", "run git diff check after execution")
 	pkrun.Printf(ctx, "  %-*s  %s\n", maxWidth, "-h, --help", "show help")
+	pkrun.Printf(ctx, "  %-*s  %s\n", maxWidth, "--json", "emit task plan as JSON instead of executing")
 	pkrun.Printf(
 		ctx,
 		"  %-*s  %s\n",

--- a/pk/cli.go
+++ b/pk/cli.go
@@ -96,7 +96,7 @@ func run(cfg *Config) (*executionTracker, error) {
 		if len(remaining) > 0 {
 			taskName = remaining[0]
 		}
-		if err := emitInvocationJSON(plan, taskName, stdoutFromContext(ctx)); err != nil {
+		if err := emitInvocationJSON(ctx, plan, taskName, stdoutFromContext(ctx)); err != nil {
 			return nil, err
 		}
 		return nil, nil
@@ -140,6 +140,9 @@ func run(cfg *Config) (*executionTracker, error) {
 			// Builtins run directly without path context.
 			if err := instance.task.run(ctx); err != nil {
 				return nil, err
+			}
+			if instance.task.Name == execTask.Name {
+				return nil, nil
 			}
 			return nil, runPostActions(ctx)
 		}

--- a/pk/cli.go
+++ b/pk/cli.go
@@ -52,6 +52,7 @@ func run(cfg *Config) (*executionTracker, error) {
 	globalFlags.BoolVar(&showHelp, "h", false, "show help")
 	globalFlags.BoolVar(&showHelp, "help", false, "show help")
 	globalFlags.BoolVar(&showVersion, "version", false, "show version")
+	globalFlags.BoolVar(&jsonOut, "j", false, "emit task plan as JSON instead of executing")
 	globalFlags.BoolVar(&jsonOut, "json", false, "emit task plan as JSON instead of executing")
 
 	// Parse flags
@@ -340,7 +341,7 @@ func printHelp(ctx context.Context, _ *Config, plan *Plan) {
 	}
 
 	allNames := []string{
-		"-c, --commits", "-g, --gitdiff", "-h, --help", "--json",
+		"-c, --commits", "-g, --gitdiff", "-h, --help", "-j, --json",
 		"-s, --serial", "-v, --verbose", "--version",
 	}
 	for _, t := range builtins {
@@ -367,7 +368,7 @@ func printHelp(ctx context.Context, _ *Config, plan *Plan) {
 	pkrun.Printf(ctx, "  %-*s  %s\n", maxWidth, "-c, --commits", "validate conventional commits after execution")
 	pkrun.Printf(ctx, "  %-*s  %s\n", maxWidth, "-g, --gitdiff", "run git diff check after execution")
 	pkrun.Printf(ctx, "  %-*s  %s\n", maxWidth, "-h, --help", "show help")
-	pkrun.Printf(ctx, "  %-*s  %s\n", maxWidth, "--json", "emit task plan as JSON instead of executing")
+	pkrun.Printf(ctx, "  %-*s  %s\n", maxWidth, "-j, --json", "emit task plan as JSON instead of executing")
 	pkrun.Printf(
 		ctx,
 		"  %-*s  %s\n",

--- a/pk/cli.go
+++ b/pk/cli.go
@@ -121,6 +121,7 @@ func run(cfg *Config) (*executionTracker, error) {
 				}
 				return nil, fmt.Errorf("parsing flags for task %q: %w", taskName, err)
 			}
+			ctx = context.WithValue(ctx, ctxkey.TaskArgs{}, instance.task.flagSet.Args())
 			// Extract only explicitly-set CLI flags (not defaults) for
 			// highest-priority override in task.run().
 			cliFlags := make(map[string]any)

--- a/pk/execjson.go
+++ b/pk/execjson.go
@@ -1,0 +1,441 @@
+package pk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+
+	"github.com/fredrikaverpil/pocket/pk/internal/ctxkey"
+	pkrun "github.com/fredrikaverpil/pocket/pk/run"
+)
+
+// execJSONVersion is the schema version supported by the exec builtin.
+const execJSONVersion = 1
+
+// jsonRoot is the root document for JSON-driven task execution.
+type jsonRoot struct {
+	Version int       `json:"version"`
+	Tree    *jsonNode `json:"tree"`
+}
+
+// jsonNode is a single node in the JSON execution tree. Each node must have
+// exactly one kind key set: exec, serial, or parallel.
+type jsonNode struct {
+	Exec     []string    `json:"exec,omitempty"`
+	Serial   []*jsonNode `json:"serial,omitempty"`
+	Parallel []*jsonNode `json:"parallel,omitempty"`
+	Name     string      `json:"name,omitempty"`
+	Paths    []string    `json:"paths,omitempty"`
+}
+
+// parseExecJSON reads and validates a JSON execution document from r.
+// Unknown fields and malformed shapes return an error.
+func parseExecJSON(r io.Reader) (*jsonRoot, error) {
+	dec := json.NewDecoder(r)
+	dec.DisallowUnknownFields()
+	var root jsonRoot
+	if err := dec.Decode(&root); err != nil {
+		return nil, fmt.Errorf("decoding JSON: %w", err)
+	}
+	if dec.More() {
+		return nil, fmt.Errorf("unexpected trailing content after root document")
+	}
+	if root.Version != execJSONVersion {
+		return nil, fmt.Errorf("version: unsupported value %d (expected %d)", root.Version, execJSONVersion)
+	}
+	if root.Tree == nil {
+		return nil, fmt.Errorf("tree: required")
+	}
+	if err := validateNode(root.Tree, "tree"); err != nil {
+		return nil, err
+	}
+	return &root, nil
+}
+
+// validateNode enforces the v1 schema rules on a single node and its children.
+func validateNode(n *jsonNode, path string) error {
+	if n == nil {
+		return fmt.Errorf("%s: node is null", path)
+	}
+	var kinds []string
+	if n.Exec != nil {
+		kinds = append(kinds, "exec")
+	}
+	if n.Serial != nil {
+		kinds = append(kinds, "serial")
+	}
+	if n.Parallel != nil {
+		kinds = append(kinds, "parallel")
+	}
+	switch len(kinds) {
+	case 0:
+		return fmt.Errorf("%s: expected one of: exec, serial, parallel", path)
+	case 1:
+		// valid
+	default:
+		return fmt.Errorf("%s: expected exactly one of exec/serial/parallel, got %v", path, kinds)
+	}
+
+	switch kinds[0] {
+	case "exec":
+		if len(n.Exec) == 0 {
+			return fmt.Errorf("%s.exec: empty array", path)
+		}
+		if n.Name == "" {
+			return fmt.Errorf("%s.name: required for exec nodes", path)
+		}
+		if n.Paths != nil && len(n.Paths) == 0 {
+			return fmt.Errorf("%s.paths: empty array (omit the field to default to root)", path)
+		}
+		for i, p := range n.Paths {
+			if p == "" {
+				return fmt.Errorf("%s.paths[%d]: empty path", path, i)
+			}
+		}
+	case "serial", "parallel":
+		if n.Name != "" {
+			return fmt.Errorf("%s.name: not allowed on %s composition", path, kinds[0])
+		}
+		if n.Paths != nil {
+			return fmt.Errorf("%s.paths: not allowed on %s composition", path, kinds[0])
+		}
+		children := n.Serial
+		if kinds[0] == "parallel" {
+			children = n.Parallel
+		}
+		if len(children) == 0 {
+			return fmt.Errorf("%s.%s: empty array", path, kinds[0])
+		}
+		for i, c := range children {
+			if err := validateNode(c, fmt.Sprintf("%s.%s[%d]", path, kinds[0], i)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// taskNodeInfo carries data needed to populate the Plan for one JSON task node.
+type taskNodeInfo struct {
+	task          *Task
+	name          string
+	resolvedPaths []string
+}
+
+// buildRunnable converts a validated jsonNode tree to a Runnable.
+// Encountered task nodes are appended to taskNodes for later Plan construction.
+func buildRunnable(n *jsonNode, taskNodes *[]taskNodeInfo) (Runnable, error) {
+	switch {
+	case n.Exec != nil:
+		argv := slices.Clone(n.Exec)
+		paths := slices.Clone(n.Paths)
+		if len(paths) == 0 {
+			paths = []string{"."}
+		}
+		t := &Task{
+			Name:  n.Name,
+			Usage: "JSON exec task",
+			Do: func(ctx context.Context) error {
+				return pkrun.Exec(ctx, argv[0], argv[1:]...)
+			},
+		}
+		if err := t.buildFlagSet(); err != nil {
+			return nil, fmt.Errorf("task %q: %w", n.Name, err)
+		}
+		*taskNodes = append(*taskNodes, taskNodeInfo{
+			task:          t,
+			name:          n.Name,
+			resolvedPaths: paths,
+		})
+		// At root only: task.run prints the simple ":: name" header, no wrap needed.
+		if len(paths) == 1 && paths[0] == "." {
+			return t, nil
+		}
+		return &pathFilter{inner: t, resolvedPaths: paths}, nil
+
+	case n.Serial != nil:
+		children := make([]Runnable, len(n.Serial))
+		for i, c := range n.Serial {
+			r, err := buildRunnable(c, taskNodes)
+			if err != nil {
+				return nil, err
+			}
+			children[i] = r
+		}
+		return Serial(children...), nil
+
+	case n.Parallel != nil:
+		children := make([]Runnable, len(n.Parallel))
+		for i, c := range n.Parallel {
+			r, err := buildRunnable(c, taskNodes)
+			if err != nil {
+				return nil, err
+			}
+			children[i] = r
+		}
+		return Parallel(children...), nil
+	}
+	return nil, fmt.Errorf("invalid node: no kind key set")
+}
+
+// buildPlanFromJSON constructs a Plan from a JSON-derived tree and collected
+// task nodes. Path mappings merge resolvedPaths for any task name appearing
+// multiple times.
+func buildPlanFromJSON(tree Runnable, taskNodes []taskNodeInfo) *Plan {
+	taskInstances := make([]taskInstance, 0, len(taskNodes))
+	pathMappings := make(map[string]pathInfo, len(taskNodes))
+	seen := make(map[string]int) // name -> index into taskInstances
+
+	for _, info := range taskNodes {
+		if idx, ok := seen[info.name]; ok {
+			existing := pathMappings[info.name]
+			merged := slices.Clone(existing.resolvedPaths)
+			for _, p := range info.resolvedPaths {
+				if !slices.Contains(merged, p) {
+					merged = append(merged, p)
+				}
+			}
+			pathMappings[info.name] = pathInfo{resolvedPaths: merged, includePaths: merged}
+			taskInstances[idx].resolvedPaths = merged
+			continue
+		}
+		paths := slices.Clone(info.resolvedPaths)
+		pathMappings[info.name] = pathInfo{resolvedPaths: paths, includePaths: paths}
+		seen[info.name] = len(taskInstances)
+		taskInstances = append(taskInstances, taskInstance{
+			task:          info.task,
+			name:          info.name,
+			resolvedPaths: paths,
+		})
+	}
+
+	taskIndex := make(map[string]*taskInstance, len(taskInstances))
+	for i := range taskInstances {
+		taskIndex[taskInstances[i].name] = &taskInstances[i]
+	}
+
+	return &Plan{
+		tree:              tree,
+		taskInstances:     taskInstances,
+		taskIndex:         taskIndex,
+		pathMappings:      pathMappings,
+		moduleDirectories: []string{"."},
+	}
+}
+
+// runExecJSON parses a JSON document from r and executes the resulting tree.
+// Parse and validation errors are emitted as JSON to stderr.
+func runExecJSON(ctx context.Context, r io.Reader) error {
+	root, err := parseExecJSON(r)
+	if err != nil {
+		emitJSONError(ctx, err)
+		return err
+	}
+	var taskNodes []taskNodeInfo
+	tree, err := buildRunnable(root.Tree, &taskNodes)
+	if err != nil {
+		emitJSONError(ctx, err)
+		return err
+	}
+	plan := buildPlanFromJSON(tree, taskNodes)
+
+	ctx = context.WithValue(ctx, ctxkey.Plan{}, plan)
+	ctx = withExecutionTracker(ctx, newExecutionTracker())
+	return tree.run(ctx)
+}
+
+// emitJSONError writes a JSON error object to stderr.
+func emitJSONError(ctx context.Context, err error) {
+	w := stderrFromContext(ctx)
+	obj := map[string]string{"error": err.Error()}
+	data, mErr := json.Marshal(obj)
+	if mErr != nil {
+		fmt.Fprintf(w, "{\"error\":%q}\n", err.Error())
+		return
+	}
+	fmt.Fprintln(w, string(data))
+}
+
+// stderrFromContext returns the stderr writer from context, defaulting to
+// os.Stderr if none is set.
+func stderrFromContext(ctx context.Context) io.Writer {
+	if out := pkrun.OutputFromContext(ctx); out != nil {
+		return out.Stderr
+	}
+	return os.Stderr
+}
+
+// stdoutFromContext returns the stdout writer from context, defaulting to
+// os.Stdout if none is set.
+func stdoutFromContext(ctx context.Context) io.Writer {
+	if out := pkrun.OutputFromContext(ctx); out != nil {
+		return out.Stdout
+	}
+	return os.Stdout
+}
+
+// emitInvocationJSON writes the JSON representation of a Plan invocation.
+// If taskName is empty the whole Auto tree is emitted; otherwise only the
+// named task slice. Returns an error if the named task does not exist.
+func emitInvocationJSON(p *Plan, taskName string, w io.Writer) error {
+	if p == nil {
+		return fmt.Errorf("plan is nil")
+	}
+	var tree map[string]any
+	if taskName == "" {
+		if p.tree == nil {
+			tree = map[string]any{"serial": []map[string]any{}}
+		} else {
+			tree = emitJSONNode(p.tree, "", p)
+		}
+	} else {
+		inst := p.taskInstanceByName(taskName)
+		if inst == nil {
+			return fmt.Errorf("unknown task %q", taskName)
+		}
+		paths := inst.resolvedPaths
+		if len(paths) == 0 {
+			paths = []string{"."}
+		}
+		tree = map[string]any{
+			"name":  inst.name,
+			"paths": paths,
+		}
+	}
+	doc := map[string]any{
+		"version": execJSONVersion,
+		"tree":    tree,
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(doc)
+}
+
+// emitJSONNode converts a Runnable to its JSON representation, mirroring the
+// schema used by the exec builtin (minus the exec field, which is not
+// derivable from Go-defined task bodies).
+func emitJSONNode(r Runnable, nameSuffix string, p *Plan) map[string]any {
+	switch v := r.(type) {
+	case *Task:
+		effectiveName := v.Name
+		if nameSuffix != "" {
+			effectiveName = v.Name + ":" + nameSuffix
+		}
+		paths := []string{"."}
+		if info, ok := p.pathMappings[effectiveName]; ok && len(info.resolvedPaths) > 0 {
+			paths = info.resolvedPaths
+		}
+		return map[string]any{
+			"name":  effectiveName,
+			"paths": paths,
+		}
+	case *serial:
+		children := make([]map[string]any, 0, len(v.runnables))
+		for _, child := range v.runnables {
+			children = append(children, emitJSONNode(child, nameSuffix, p))
+		}
+		return map[string]any{"serial": children}
+	case *parallel:
+		children := make([]map[string]any, 0, len(v.runnables))
+		for _, child := range v.runnables {
+			children = append(children, emitJSONNode(child, nameSuffix, p))
+		}
+		return map[string]any{"parallel": children}
+	case *pathFilter:
+		childSuffix := nameSuffix
+		if v.nameSuffix != "" {
+			if nameSuffix != "" {
+				childSuffix = nameSuffix + ":" + v.nameSuffix
+			} else {
+				childSuffix = v.nameSuffix
+			}
+		}
+		return emitJSONNode(v.inner, childSuffix, p)
+	}
+	return map[string]any{}
+}
+
+// execJSONSchema is the JSON Schema document for the v1 exec format.
+const execJSONSchema = `{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Pocket exec v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "tree"],
+  "properties": {
+    "version": {"type": "integer", "const": 1},
+    "tree": {"$ref": "#/definitions/node"}
+  },
+  "definitions": {
+    "node": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "exec": {
+          "type": "array",
+          "items": {"type": "string"},
+          "minItems": 1
+        },
+        "serial": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/node"},
+          "minItems": 1
+        },
+        "parallel": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/node"},
+          "minItems": 1
+        },
+        "name": {"type": "string", "minLength": 1},
+        "paths": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "minItems": 1
+        }
+      },
+      "oneOf": [
+        {
+          "required": ["exec", "name"],
+          "not": {
+            "anyOf": [
+              {"required": ["serial"]},
+              {"required": ["parallel"]}
+            ]
+          }
+        },
+        {
+          "required": ["serial"],
+          "not": {
+            "anyOf": [
+              {"required": ["exec"]},
+              {"required": ["parallel"]},
+              {"required": ["name"]},
+              {"required": ["paths"]}
+            ]
+          }
+        },
+        {
+          "required": ["parallel"],
+          "not": {
+            "anyOf": [
+              {"required": ["exec"]},
+              {"required": ["serial"]},
+              {"required": ["name"]},
+              {"required": ["paths"]}
+            ]
+          }
+        }
+      ]
+    }
+  }
+}`
+
+// printExecSchema writes the JSON Schema document to stdout.
+func printExecSchema(ctx context.Context) error {
+	w := stdoutFromContext(ctx)
+	_, err := fmt.Fprintln(w, execJSONSchema)
+	return err
+}

--- a/pk/execjson.go
+++ b/pk/execjson.go
@@ -3,10 +3,12 @@ package pk
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"slices"
+	"strings"
 
 	"github.com/fredrikaverpil/pocket/pk/internal/ctxkey"
 	pkrun "github.com/fredrikaverpil/pocket/pk/run"
@@ -38,7 +40,7 @@ func parseExecJSON(r io.Reader) (*jsonRoot, error) {
 	dec.DisallowUnknownFields()
 	var root jsonRoot
 	if err := dec.Decode(&root); err != nil {
-		return nil, fmt.Errorf("decoding JSON: %w", err)
+		return nil, friendlyDecodeError(err)
 	}
 	if dec.More() {
 		return nil, fmt.Errorf("unexpected trailing content after root document")
@@ -53,6 +55,49 @@ func parseExecJSON(r io.Reader) (*jsonRoot, error) {
 		return nil, err
 	}
 	return &root, nil
+}
+
+// friendlyDecodeError rewrites Go's encoding/json errors into agent-friendly
+// messages: field paths instead of Go types, schema-oriented expected types,
+// and a stripped "json: " prefix.
+func friendlyDecodeError(err error) error {
+	if typeErr, ok := errors.AsType[*json.UnmarshalTypeError](err); ok {
+		field := typeErr.Field
+		if field == "" {
+			field = "<root>"
+		}
+		return fmt.Errorf("%s: expected %s, got %s", field, expectedSchemaType(field), typeErr.Value)
+	}
+	if synErr, ok := errors.AsType[*json.SyntaxError](err); ok {
+		return fmt.Errorf("invalid JSON at byte offset %d: %s", synErr.Offset, synErr.Error())
+	}
+	// Unknown-field errors from DisallowUnknownFields are plain `error` values
+	// with message `json: unknown field "X"`. Strip the redundant prefix.
+	msg := strings.TrimPrefix(err.Error(), "json: ")
+	return errors.New(msg)
+}
+
+// expectedSchemaType returns the JSON-schema type expected for a field path
+// like "tree.serial.exec" or "version". Trailing segment determines the type.
+func expectedSchemaType(field string) string {
+	last := field
+	if idx := strings.LastIndex(field, "."); idx >= 0 {
+		last = field[idx+1:]
+	}
+	switch last {
+	case "version":
+		return "integer"
+	case "tree":
+		return "object"
+	case "exec", "paths":
+		return "array of strings"
+	case "serial", "parallel":
+		return "array of nodes"
+	case "name":
+		return "string"
+	default:
+		return "different type"
+	}
 }
 
 // validateNode enforces the v1 schema rules on a single node and its children.

--- a/pk/execjson.go
+++ b/pk/execjson.go
@@ -17,20 +17,26 @@ import (
 // execJSONVersion is the schema version supported by the exec builtin.
 const execJSONVersion = 1
 
+const (
+	jsonNodeTypeTask     = "task"
+	jsonNodeTypeCommand  = "command"
+	jsonNodeTypeSerial   = "serial"
+	jsonNodeTypeParallel = "parallel"
+)
+
 // jsonRoot is the root document for JSON-driven task execution.
 type jsonRoot struct {
 	Version int       `json:"version"`
 	Tree    *jsonNode `json:"tree"`
 }
 
-// jsonNode is a single node in the JSON execution tree. Each node must have
-// exactly one kind key set: exec, serial, or parallel.
+// jsonNode is a single node in the JSON execution tree.
 type jsonNode struct {
-	Exec     []string    `json:"exec,omitempty"`
-	Serial   []*jsonNode `json:"serial,omitempty"`
-	Parallel []*jsonNode `json:"parallel,omitempty"`
+	Type     string      `json:"type"`
 	Name     string      `json:"name,omitempty"`
+	Argv     []string    `json:"argv,omitempty"`
 	Paths    []string    `json:"paths,omitempty"`
+	Children []*jsonNode `json:"children,omitempty"`
 }
 
 // parseExecJSON reads and validates a JSON execution document from r.
@@ -42,7 +48,11 @@ func parseExecJSON(r io.Reader) (*jsonRoot, error) {
 	if err := dec.Decode(&root); err != nil {
 		return nil, friendlyDecodeError(err)
 	}
-	if dec.More() {
+	var trailing struct{}
+	if err := dec.Decode(&trailing); err != io.EOF {
+		if err != nil {
+			return nil, friendlyDecodeError(err)
+		}
 		return nil, fmt.Errorf("unexpected trailing content after root document")
 	}
 	if root.Version != execJSONVersion {
@@ -71,14 +81,12 @@ func friendlyDecodeError(err error) error {
 	if synErr, ok := errors.AsType[*json.SyntaxError](err); ok {
 		return fmt.Errorf("invalid JSON at byte offset %d: %s", synErr.Offset, synErr.Error())
 	}
-	// Unknown-field errors from DisallowUnknownFields are plain `error` values
-	// with message `json: unknown field "X"`. Strip the redundant prefix.
 	msg := strings.TrimPrefix(err.Error(), "json: ")
 	return errors.New(msg)
 }
 
 // expectedSchemaType returns the JSON-schema type expected for a field path
-// like "tree.serial.exec" or "version". Trailing segment determines the type.
+// like "tree.children.argv" or "version". Trailing segment determines the type.
 func expectedSchemaType(field string) string {
 	last := field
 	if idx := strings.LastIndex(field, "."); idx >= 0 {
@@ -89,12 +97,12 @@ func expectedSchemaType(field string) string {
 		return "integer"
 	case "tree":
 		return "object"
-	case "exec", "paths":
-		return "array of strings"
-	case "serial", "parallel":
-		return "array of nodes"
-	case "name":
+	case "type", "name":
 		return "string"
+	case "argv", "paths":
+		return "array of strings"
+	case "children":
+		return "array of nodes"
 	default:
 		return "different type"
 	}
@@ -105,155 +113,244 @@ func validateNode(n *jsonNode, path string) error {
 	if n == nil {
 		return fmt.Errorf("%s: node is null", path)
 	}
-	var kinds []string
-	if n.Exec != nil {
-		kinds = append(kinds, "exec")
-	}
-	if n.Serial != nil {
-		kinds = append(kinds, "serial")
-	}
-	if n.Parallel != nil {
-		kinds = append(kinds, "parallel")
-	}
-	switch len(kinds) {
-	case 0:
-		return fmt.Errorf("%s: expected one of: exec, serial, parallel", path)
-	case 1:
-		// valid
-	default:
-		return fmt.Errorf("%s: expected exactly one of exec/serial/parallel, got %v", path, kinds)
+	if n.Type == "" {
+		return fmt.Errorf("%s.type: required", path)
 	}
 
-	switch kinds[0] {
-	case "exec":
-		if len(n.Exec) == 0 {
-			return fmt.Errorf("%s.exec: empty array", path)
-		}
+	switch n.Type {
+	case jsonNodeTypeTask:
 		if n.Name == "" {
-			return fmt.Errorf("%s.name: required for exec nodes", path)
+			return fmt.Errorf("%s.name: required for task nodes", path)
 		}
-		if n.Paths != nil && len(n.Paths) == 0 {
-			return fmt.Errorf("%s.paths: empty array (omit the field to default to root)", path)
+		if n.Argv != nil {
+			return fmt.Errorf("%s.argv: not allowed on task nodes", path)
 		}
-		for i, p := range n.Paths {
-			if p == "" {
-				return fmt.Errorf("%s.paths[%d]: empty path", path, i)
-			}
+		if n.Children != nil {
+			return fmt.Errorf("%s.children: not allowed on task nodes", path)
 		}
-	case "serial", "parallel":
+		return validatePaths(n.Paths, path)
+
+	case jsonNodeTypeCommand:
+		if n.Name == "" {
+			return fmt.Errorf("%s.name: required for command nodes", path)
+		}
+		if len(n.Argv) == 0 {
+			return fmt.Errorf("%s.argv: empty array", path)
+		}
+		if n.Children != nil {
+			return fmt.Errorf("%s.children: not allowed on command nodes", path)
+		}
+		return validatePaths(n.Paths, path)
+
+	case jsonNodeTypeSerial, jsonNodeTypeParallel:
 		if n.Name != "" {
-			return fmt.Errorf("%s.name: not allowed on %s composition", path, kinds[0])
+			return fmt.Errorf("%s.name: not allowed on %s nodes", path, n.Type)
+		}
+		if n.Argv != nil {
+			return fmt.Errorf("%s.argv: not allowed on %s nodes", path, n.Type)
 		}
 		if n.Paths != nil {
-			return fmt.Errorf("%s.paths: not allowed on %s composition", path, kinds[0])
+			return fmt.Errorf("%s.paths: not allowed on %s nodes", path, n.Type)
 		}
-		children := n.Serial
-		if kinds[0] == "parallel" {
-			children = n.Parallel
+		if len(n.Children) == 0 {
+			return fmt.Errorf("%s.children: empty array", path)
 		}
-		if len(children) == 0 {
-			return fmt.Errorf("%s.%s: empty array", path, kinds[0])
-		}
-		for i, c := range children {
-			if err := validateNode(c, fmt.Sprintf("%s.%s[%d]", path, kinds[0], i)); err != nil {
+		for i, child := range n.Children {
+			if err := validateNode(child, fmt.Sprintf("%s.children[%d]", path, i)); err != nil {
 				return err
 			}
+		}
+		return nil
+
+	default:
+		return fmt.Errorf(
+			"%s.type: unsupported value %q (expected task, command, serial, parallel)",
+			path,
+			n.Type,
+		)
+	}
+}
+
+// validatePaths validates optional task or command paths.
+func validatePaths(paths []string, path string) error {
+	if paths == nil {
+		return nil
+	}
+	if len(paths) == 0 {
+		return fmt.Errorf("%s.paths: empty array (omit the field to default to the task's paths)", path)
+	}
+	for i, p := range paths {
+		if p == "" {
+			return fmt.Errorf("%s.paths[%d]: empty path", path, i)
 		}
 	}
 	return nil
 }
 
-// taskNodeInfo carries data needed to populate the Plan for one JSON task node.
+// taskNodeInfo carries data needed to populate the Plan for one JSON leaf node.
 type taskNodeInfo struct {
 	task          *Task
 	name          string
 	resolvedPaths []string
+	flags         map[string]any
+	isManual      bool
+	verbose       bool
+}
+
+// jsonTaskRef executes an existing Pocket task reference from JSON.
+type jsonTaskRef struct {
+	task  *Task
+	name  string
+	paths []string
+}
+
+// run implements Runnable for task references in JSON documents.
+func (r *jsonTaskRef) run(ctx context.Context) error {
+	baseName := r.task.Name
+	if len(r.name) > len(baseName) && r.name[:len(baseName)] == baseName && r.name[len(baseName)] == ':' {
+		ctx = contextWithNameSuffix(ctx, r.name[len(baseName)+1:])
+	}
+	for _, path := range r.paths {
+		pathCtx := pkrun.ContextWithPath(ctx, path)
+		if err := r.task.run(pathCtx); err != nil {
+			return fmt.Errorf("task %s in %s: %w", r.name, path, err)
+		}
+	}
+	return nil
 }
 
 // buildRunnable converts a validated jsonNode tree to a Runnable.
-// Encountered task nodes are appended to taskNodes for later Plan construction.
-func buildRunnable(n *jsonNode, taskNodes *[]taskNodeInfo) (Runnable, error) {
-	switch {
-	case n.Exec != nil:
-		argv := slices.Clone(n.Exec)
-		paths := slices.Clone(n.Paths)
-		if len(paths) == 0 {
-			paths = []string{"."}
+// Encountered leaf nodes are appended to taskNodes for later Plan construction.
+func buildRunnable(n *jsonNode, taskNodes *[]taskNodeInfo, basePlan *Plan) (Runnable, error) {
+	switch n.Type {
+	case jsonNodeTypeCommand:
+		if basePlan != nil && basePlan.taskInstanceByName(n.Name) != nil {
+			return nil, fmt.Errorf("command %q conflicts with existing Pocket task", n.Name)
 		}
+		argv := slices.Clone(n.Argv)
+		paths := resolvedJSONPaths(n.Paths, nil)
 		t := &Task{
 			Name:  n.Name,
-			Usage: "JSON exec task",
+			Usage: "JSON command task",
 			Do: func(ctx context.Context) error {
 				return pkrun.Exec(ctx, argv[0], argv[1:]...)
 			},
 		}
 		if err := t.buildFlagSet(); err != nil {
-			return nil, fmt.Errorf("task %q: %w", n.Name, err)
+			return nil, fmt.Errorf("command %q: %w", n.Name, err)
 		}
-		*taskNodes = append(*taskNodes, taskNodeInfo{
-			task:          t,
-			name:          n.Name,
-			resolvedPaths: paths,
-		})
-		// At root only: task.run prints the simple ":: name" header, no wrap needed.
+		*taskNodes = append(*taskNodes, taskNodeInfo{task: t, name: n.Name, resolvedPaths: paths})
 		if len(paths) == 1 && paths[0] == "." {
 			return t, nil
 		}
 		return &pathFilter{inner: t, resolvedPaths: paths}, nil
 
-	case n.Serial != nil:
-		children := make([]Runnable, len(n.Serial))
-		for i, c := range n.Serial {
-			r, err := buildRunnable(c, taskNodes)
+	case jsonNodeTypeTask:
+		if basePlan == nil {
+			return nil, fmt.Errorf("task %q: no Pocket plan available", n.Name)
+		}
+		inst := basePlan.taskInstanceByName(n.Name)
+		if inst == nil {
+			return nil, fmt.Errorf("task %q: not found in Pocket plan", n.Name)
+		}
+		paths := resolvedJSONPaths(n.Paths, inst.resolvedPaths)
+		*taskNodes = append(*taskNodes, taskNodeInfo{
+			task:          inst.task,
+			name:          inst.name,
+			resolvedPaths: paths,
+			flags:         inst.flags,
+			isManual:      inst.isManual,
+			verbose:       inst.verbose,
+		})
+		return &jsonTaskRef{task: inst.task, name: inst.name, paths: paths}, nil
+
+	case jsonNodeTypeSerial:
+		children := make([]Runnable, len(n.Children))
+		for i, child := range n.Children {
+			runnable, err := buildRunnable(child, taskNodes, basePlan)
 			if err != nil {
 				return nil, err
 			}
-			children[i] = r
+			children[i] = runnable
 		}
 		return Serial(children...), nil
 
-	case n.Parallel != nil:
-		children := make([]Runnable, len(n.Parallel))
-		for i, c := range n.Parallel {
-			r, err := buildRunnable(c, taskNodes)
+	case jsonNodeTypeParallel:
+		children := make([]Runnable, len(n.Children))
+		for i, child := range n.Children {
+			runnable, err := buildRunnable(child, taskNodes, basePlan)
 			if err != nil {
 				return nil, err
 			}
-			children[i] = r
+			children[i] = runnable
 		}
 		return Parallel(children...), nil
 	}
-	return nil, fmt.Errorf("invalid node: no kind key set")
+	return nil, fmt.Errorf("invalid node type %q", n.Type)
+}
+
+// resolvedJSONPaths returns explicit JSON paths, fallback paths, or root.
+func resolvedJSONPaths(paths, fallback []string) []string {
+	if len(paths) > 0 {
+		return slices.Clone(paths)
+	}
+	if len(fallback) > 0 {
+		return slices.Clone(fallback)
+	}
+	return []string{"."}
 }
 
 // buildPlanFromJSON constructs a Plan from a JSON-derived tree and collected
-// task nodes. Path mappings merge resolvedPaths for any task name appearing
-// multiple times.
-func buildPlanFromJSON(tree Runnable, taskNodes []taskNodeInfo) *Plan {
-	taskInstances := make([]taskInstance, 0, len(taskNodes))
-	pathMappings := make(map[string]pathInfo, len(taskNodes))
-	seen := make(map[string]int) // name -> index into taskInstances
+// leaf nodes. It preserves the base Pocket plan so referenced tasks keep their
+// flags, path mappings, and composed subtasks.
+func buildPlanFromJSON(tree Runnable, taskNodes []taskNodeInfo, basePlan *Plan) *Plan {
+	var taskInstances []taskInstance
+	pathMappings := make(map[string]pathInfo)
+	moduleDirectories := []string{"."}
+
+	if basePlan != nil {
+		taskInstances = slices.Clone(basePlan.taskInstances)
+		pathMappings = make(map[string]pathInfo, len(basePlan.pathMappings)+len(taskNodes))
+		for name, info := range basePlan.pathMappings {
+			pathMappings[name] = info
+		}
+		moduleDirectories = slices.Clone(basePlan.moduleDirectories)
+	}
+
+	seen := make(map[string]int, len(taskInstances))
+	for i := range taskInstances {
+		seen[taskInstances[i].name] = i
+	}
+	seenJSON := make(map[string]bool, len(taskNodes))
 
 	for _, info := range taskNodes {
 		if idx, ok := seen[info.name]; ok {
-			existing := pathMappings[info.name]
-			merged := slices.Clone(existing.resolvedPaths)
-			for _, p := range info.resolvedPaths {
-				if !slices.Contains(merged, p) {
-					merged = append(merged, p)
+			paths := slices.Clone(info.resolvedPaths)
+			if seenJSON[info.name] {
+				existing := pathMappings[info.name]
+				paths = slices.Clone(existing.resolvedPaths)
+				for _, p := range info.resolvedPaths {
+					if !slices.Contains(paths, p) {
+						paths = append(paths, p)
+					}
 				}
 			}
-			pathMappings[info.name] = pathInfo{resolvedPaths: merged, includePaths: merged}
-			taskInstances[idx].resolvedPaths = merged
+			pathMappings[info.name] = pathInfo{resolvedPaths: paths, includePaths: paths}
+			taskInstances[idx].resolvedPaths = paths
+			seenJSON[info.name] = true
 			continue
 		}
 		paths := slices.Clone(info.resolvedPaths)
 		pathMappings[info.name] = pathInfo{resolvedPaths: paths, includePaths: paths}
 		seen[info.name] = len(taskInstances)
+		seenJSON[info.name] = true
 		taskInstances = append(taskInstances, taskInstance{
 			task:          info.task,
 			name:          info.name,
 			resolvedPaths: paths,
+			flags:         info.flags,
+			isManual:      info.isManual,
+			verbose:       info.verbose,
 		})
 	}
 
@@ -267,7 +364,7 @@ func buildPlanFromJSON(tree Runnable, taskNodes []taskNodeInfo) *Plan {
 		taskInstances:     taskInstances,
 		taskIndex:         taskIndex,
 		pathMappings:      pathMappings,
-		moduleDirectories: []string{"."},
+		moduleDirectories: moduleDirectories,
 	}
 }
 
@@ -279,13 +376,14 @@ func runExecJSON(ctx context.Context, r io.Reader) error {
 		emitJSONError(ctx, err)
 		return err
 	}
+	basePlan := planFromContext(ctx)
 	var taskNodes []taskNodeInfo
-	tree, err := buildRunnable(root.Tree, &taskNodes)
+	tree, err := buildRunnable(root.Tree, &taskNodes, basePlan)
 	if err != nil {
 		emitJSONError(ctx, err)
 		return err
 	}
-	plan := buildPlanFromJSON(tree, taskNodes)
+	plan := buildPlanFromJSON(tree, taskNodes, basePlan)
 
 	ctx = context.WithValue(ctx, ctxkey.Plan{}, plan)
 	ctx = withExecutionTracker(ctx, newExecutionTracker())
@@ -332,7 +430,7 @@ func emitInvocationJSON(p *Plan, taskName string, w io.Writer) error {
 	var tree map[string]any
 	if taskName == "" {
 		if p.tree == nil {
-			tree = map[string]any{"serial": []map[string]any{}}
+			tree = map[string]any{"type": jsonNodeTypeSerial, "children": []map[string]any{}}
 		} else {
 			tree = emitJSONNode(p.tree, "", p)
 		}
@@ -346,6 +444,7 @@ func emitInvocationJSON(p *Plan, taskName string, w io.Writer) error {
 			paths = []string{"."}
 		}
 		tree = map[string]any{
+			"type":  jsonNodeTypeTask,
 			"name":  inst.name,
 			"paths": paths,
 		}
@@ -359,9 +458,7 @@ func emitInvocationJSON(p *Plan, taskName string, w io.Writer) error {
 	return enc.Encode(doc)
 }
 
-// emitJSONNode converts a Runnable to its JSON representation, mirroring the
-// schema used by the exec builtin (minus the exec field, which is not
-// derivable from Go-defined task bodies).
+// emitJSONNode converts a Runnable to its JSON representation.
 func emitJSONNode(r Runnable, nameSuffix string, p *Plan) map[string]any {
 	switch v := r.(type) {
 	case *Task:
@@ -374,6 +471,7 @@ func emitJSONNode(r Runnable, nameSuffix string, p *Plan) map[string]any {
 			paths = info.resolvedPaths
 		}
 		return map[string]any{
+			"type":  jsonNodeTypeTask,
 			"name":  effectiveName,
 			"paths": paths,
 		}
@@ -382,13 +480,13 @@ func emitJSONNode(r Runnable, nameSuffix string, p *Plan) map[string]any {
 		for _, child := range v.runnables {
 			children = append(children, emitJSONNode(child, nameSuffix, p))
 		}
-		return map[string]any{"serial": children}
+		return map[string]any{"type": jsonNodeTypeSerial, "children": children}
 	case *parallel:
 		children := make([]map[string]any, 0, len(v.runnables))
 		for _, child := range v.runnables {
 			children = append(children, emitJSONNode(child, nameSuffix, p))
 		}
-		return map[string]any{"parallel": children}
+		return map[string]any{"type": jsonNodeTypeParallel, "children": children}
 	case *pathFilter:
 		childSuffix := nameSuffix
 		if v.nameSuffix != "" {
@@ -418,60 +516,46 @@ const execJSONSchema = `{
     "node": {
       "type": "object",
       "additionalProperties": false,
+      "required": ["type"],
       "properties": {
-        "exec": {
+        "type": {"type": "string", "enum": ["task", "command", "serial", "parallel"]},
+        "name": {"type": "string", "minLength": 1},
+        "argv": {
           "type": "array",
           "items": {"type": "string"},
           "minItems": 1
         },
-        "serial": {
-          "type": "array",
-          "items": {"$ref": "#/definitions/node"},
-          "minItems": 1
-        },
-        "parallel": {
-          "type": "array",
-          "items": {"$ref": "#/definitions/node"},
-          "minItems": 1
-        },
-        "name": {"type": "string", "minLength": 1},
         "paths": {
           "type": "array",
           "items": {"type": "string", "minLength": 1},
+          "minItems": 1
+        },
+        "children": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/node"},
           "minItems": 1
         }
       },
       "oneOf": [
         {
-          "required": ["exec", "name"],
-          "not": {
-            "anyOf": [
-              {"required": ["serial"]},
-              {"required": ["parallel"]}
-            ]
-          }
+          "properties": {"type": {"const": "task"}},
+          "required": ["type", "name"],
+          "not": {"anyOf": [{"required": ["argv"]}, {"required": ["children"]}]}
         },
         {
-          "required": ["serial"],
-          "not": {
-            "anyOf": [
-              {"required": ["exec"]},
-              {"required": ["parallel"]},
-              {"required": ["name"]},
-              {"required": ["paths"]}
-            ]
-          }
+          "properties": {"type": {"const": "command"}},
+          "required": ["type", "name", "argv"],
+          "not": {"required": ["children"]}
         },
         {
-          "required": ["parallel"],
-          "not": {
-            "anyOf": [
-              {"required": ["exec"]},
-              {"required": ["serial"]},
-              {"required": ["name"]},
-              {"required": ["paths"]}
-            ]
-          }
+          "properties": {"type": {"const": "serial"}},
+          "required": ["type", "children"],
+          "not": {"anyOf": [{"required": ["name"]}, {"required": ["argv"]}, {"required": ["paths"]}]}
+        },
+        {
+          "properties": {"type": {"const": "parallel"}},
+          "required": ["type", "children"],
+          "not": {"anyOf": [{"required": ["name"]}, {"required": ["argv"]}, {"required": ["paths"]}]}
         }
       ]
     }

--- a/pk/execjson.go
+++ b/pk/execjson.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"slices"
 	"strings"
@@ -322,9 +323,7 @@ func buildPlanFromJSON(tree Runnable, taskNodes []taskNodeInfo, basePlan *Plan) 
 	if basePlan != nil {
 		taskInstances = slices.Clone(basePlan.taskInstances)
 		pathMappings = make(map[string]pathInfo, len(basePlan.pathMappings)+len(taskNodes))
-		for name, info := range basePlan.pathMappings {
-			pathMappings[name] = info
-		}
+		maps.Copy(pathMappings, basePlan.pathMappings)
 		moduleDirectories = slices.Clone(basePlan.moduleDirectories)
 	}
 

--- a/pk/execjson.go
+++ b/pk/execjson.go
@@ -26,8 +26,17 @@ const (
 
 // jsonRoot is the root document for JSON-driven task execution.
 type jsonRoot struct {
-	Version int       `json:"version"`
-	Tree    *jsonNode `json:"tree"`
+	Version int          `json:"version"`
+	Options *jsonOptions `json:"options,omitempty"`
+	Tree    *jsonNode    `json:"tree"`
+}
+
+// jsonOptions are global Pocket execution options serialized with JSON trees.
+type jsonOptions struct {
+	Verbose bool `json:"verbose,omitempty"`
+	Serial  bool `json:"serial,omitempty"`
+	GitDiff bool `json:"gitdiff,omitempty"`
+	Commits bool `json:"commits,omitempty"`
 }
 
 // jsonNode is a single node in the JSON execution tree.
@@ -95,8 +104,10 @@ func expectedSchemaType(field string) string {
 	switch last {
 	case "version":
 		return "integer"
-	case "tree":
+	case "tree", "options":
 		return "object"
+	case "verbose", "serial", "gitdiff", "commits":
+		return "boolean"
 	case "type", "name":
 		return "string"
 	case "argv", "paths":
@@ -376,6 +387,7 @@ func runExecJSON(ctx context.Context, r io.Reader) error {
 		emitJSONError(ctx, err)
 		return err
 	}
+	ctx = contextWithJSONOptions(ctx, root.Options)
 	basePlan := planFromContext(ctx)
 	var taskNodes []taskNodeInfo
 	tree, err := buildRunnable(root.Tree, &taskNodes, basePlan)
@@ -387,7 +399,10 @@ func runExecJSON(ctx context.Context, r io.Reader) error {
 
 	ctx = context.WithValue(ctx, ctxkey.Plan{}, plan)
 	ctx = withExecutionTracker(ctx, newExecutionTracker())
-	return tree.run(ctx)
+	if err := tree.run(ctx); err != nil {
+		return err
+	}
+	return runPostActions(ctx)
 }
 
 // emitJSONError writes a JSON error object to stderr.
@@ -420,10 +435,45 @@ func stdoutFromContext(ctx context.Context) io.Writer {
 	return os.Stdout
 }
 
+// contextWithJSONOptions applies JSON options to ctx. Existing true values win,
+// so CLI flags on the receiving process override or add to serialized options.
+func contextWithJSONOptions(ctx context.Context, opts *jsonOptions) context.Context {
+	if opts == nil {
+		return ctx
+	}
+	if opts.Verbose && !pkrun.Verbose(ctx) {
+		ctx = context.WithValue(ctx, ctxkey.Verbose{}, true)
+	}
+	if opts.Serial && !serialFromContext(ctx) {
+		ctx = context.WithValue(ctx, ctxkey.Serial{}, true)
+	}
+	if opts.GitDiff && !gitDiffEnabled(ctx) {
+		ctx = context.WithValue(ctx, ctxkey.GitDiff{}, true)
+	}
+	if opts.Commits && !commitsCheckEnabled(ctx) {
+		ctx = context.WithValue(ctx, ctxkey.CommitsCheck{}, true)
+	}
+	return ctx
+}
+
+// jsonOptionsFromContext returns the JSON options represented by ctx.
+func jsonOptionsFromContext(ctx context.Context) *jsonOptions {
+	opts := &jsonOptions{
+		Verbose: pkrun.Verbose(ctx),
+		Serial:  serialFromContext(ctx),
+		GitDiff: gitDiffEnabled(ctx),
+		Commits: commitsCheckEnabled(ctx),
+	}
+	if !opts.Verbose && !opts.Serial && !opts.GitDiff && !opts.Commits {
+		return nil
+	}
+	return opts
+}
+
 // emitInvocationJSON writes the JSON representation of a Plan invocation.
 // If taskName is empty the whole Auto tree is emitted; otherwise only the
 // named task slice. Returns an error if the named task does not exist.
-func emitInvocationJSON(p *Plan, taskName string, w io.Writer) error {
+func emitInvocationJSON(ctx context.Context, p *Plan, taskName string, w io.Writer) error {
 	if p == nil {
 		return fmt.Errorf("plan is nil")
 	}
@@ -452,6 +502,9 @@ func emitInvocationJSON(p *Plan, taskName string, w io.Writer) error {
 	doc := map[string]any{
 		"version": execJSONVersion,
 		"tree":    tree,
+	}
+	if opts := jsonOptionsFromContext(ctx); opts != nil {
+		doc["options"] = opts
 	}
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
@@ -510,9 +563,20 @@ const execJSONSchema = `{
   "required": ["version", "tree"],
   "properties": {
     "version": {"type": "integer", "const": 1},
+    "options": {"$ref": "#/definitions/options"},
     "tree": {"$ref": "#/definitions/node"}
   },
   "definitions": {
+    "options": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "verbose": {"type": "boolean"},
+        "serial": {"type": "boolean"},
+        "gitdiff": {"type": "boolean"},
+        "commits": {"type": "boolean"}
+      }
+    },
     "node": {
       "type": "object",
       "additionalProperties": false,

--- a/pk/execjson_test.go
+++ b/pk/execjson_test.go
@@ -127,7 +127,8 @@ func TestParseExecJSON_Errors(t *testing.T) {
 		},
 		{
 			name: "paths on composition",
-			doc:  `{"version":1,"tree":{"type":"parallel","children":[{"type":"command","argv":["x"],"name":"x"}],"paths":["."]}}`,
+			doc: `{"version":1,"tree":{"type":"parallel",` +
+				`"children":[{"type":"command","argv":["x"],"name":"x"}],"paths":["."]}}`,
 			want: "paths: not allowed on parallel nodes",
 		},
 		{
@@ -576,7 +577,8 @@ func TestEmitInvocationJSON_IncludesGlobalOptions(t *testing.T) {
 }
 
 func TestRunExecJSON_AppliesGlobalOptions(t *testing.T) {
-	doc := `{"version":1,"options":{"verbose":true,"serial":true,"gitdiff":true,"commits":true},"tree":{"type":"command","argv":["echo","x"],"name":"x"}}`
+	doc := `{"version":1,"options":{"verbose":true,"serial":true,"gitdiff":true,"commits":true},` +
+		`"tree":{"type":"command","argv":["echo","x"],"name":"x"}}`
 	root, err := parseExecJSON(strings.NewReader(doc))
 	if err != nil {
 		t.Fatal(err)

--- a/pk/execjson_test.go
+++ b/pk/execjson_test.go
@@ -139,6 +139,36 @@ func TestParseExecJSON_Errors(t *testing.T) {
 			doc:  `{"version":1,"tree":{"serial":[{"exec":["x"],"name":"x","serial":[]}]}}`,
 			want: "expected exactly one of",
 		},
+		{
+			name: "exec as string instead of array",
+			doc:  `{"version":1,"tree":{"exec":"echo hi","name":"x"}}`,
+			want: "tree.exec: expected array of strings, got string",
+		},
+		{
+			name: "paths as string instead of array",
+			doc:  `{"version":1,"tree":{"exec":["x"],"name":"x","paths":"."}}`,
+			want: "tree.paths: expected array of strings, got string",
+		},
+		{
+			name: "version as string instead of integer",
+			doc:  `{"version":"1","tree":{"exec":["x"],"name":"x"}}`,
+			want: "version: expected integer, got string",
+		},
+		{
+			name: "tree as string instead of object",
+			doc:  `{"version":1,"tree":"oops"}`,
+			want: "tree: expected object, got string",
+		},
+		{
+			name: "serial as object instead of array",
+			doc:  `{"version":1,"tree":{"serial":{}}}`,
+			want: "tree.serial: expected array of nodes, got object",
+		},
+		{
+			name: "syntax error",
+			doc:  `{"version":1,"tree":{"exec":["x"]`,
+			want: "unexpected EOF",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pk/execjson_test.go
+++ b/pk/execjson_test.go
@@ -1,0 +1,517 @@
+package pk
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/fredrikaverpil/pocket/pk/internal/ctxkey"
+	pkrun "github.com/fredrikaverpil/pocket/pk/run"
+)
+
+// execJSONTestCtx returns a context wired with output buffers suitable for
+// running JSON-driven tasks within a test.
+func execJSONTestCtx(t *testing.T) (context.Context, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	out := &pkrun.Output{Stdout: &stdout, Stderr: &stderr}
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, ctxkey.Output{}, out)
+	return ctx, &stdout, &stderr
+}
+
+func TestParseExecJSON_Valid(t *testing.T) {
+	doc := `{
+		"version": 1,
+		"tree": {
+			"serial": [
+				{"exec": ["echo", "a"], "name": "step-a"},
+				{"parallel": [
+					{"exec": ["echo", "b"], "name": "step-b"},
+					{"exec": ["echo", "c"], "name": "step-c"}
+				]}
+			]
+		}
+	}`
+	root, err := parseExecJSON(strings.NewReader(doc))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if root.Version != 1 {
+		t.Errorf("version = %d, want 1", root.Version)
+	}
+	if root.Tree == nil || len(root.Tree.Serial) != 2 {
+		t.Errorf("expected serial with 2 children, got %+v", root.Tree)
+	}
+}
+
+func TestParseExecJSON_Errors(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  string
+		want string
+	}{
+		{
+			name: "unknown top-level field",
+			doc:  `{"version":1,"tree":{"exec":["x"],"name":"x"},"extra":1}`,
+			want: `unknown field "extra"`,
+		},
+		{
+			name: "unknown nested field",
+			doc:  `{"version":1,"tree":{"exec":["x"],"name":"x","bogus":1}}`,
+			want: `unknown field "bogus"`,
+		},
+		{
+			name: "missing tree",
+			doc:  `{"version":1}`,
+			want: "tree: required",
+		},
+		{
+			name: "unsupported version",
+			doc:  `{"version":2,"tree":{"exec":["x"],"name":"x"}}`,
+			want: "version: unsupported",
+		},
+		{
+			name: "version zero (absent)",
+			doc:  `{"tree":{"exec":["x"],"name":"x"}}`,
+			want: "version: unsupported value 0",
+		},
+		{
+			name: "no kind key",
+			doc:  `{"version":1,"tree":{"name":"x"}}`,
+			want: "expected one of: exec, serial, parallel",
+		},
+		{
+			name: "two kind keys",
+			doc:  `{"version":1,"tree":{"exec":["x"],"serial":[]}}`,
+			want: "expected exactly one of",
+		},
+		{
+			name: "exec empty",
+			doc:  `{"version":1,"tree":{"exec":[],"name":"x"}}`,
+			want: "exec: empty array",
+		},
+		{
+			name: "exec missing name",
+			doc:  `{"version":1,"tree":{"exec":["x"]}}`,
+			want: "name: required",
+		},
+		{
+			name: "serial empty",
+			doc:  `{"version":1,"tree":{"serial":[]}}`,
+			want: "serial: empty array",
+		},
+		{
+			name: "parallel empty",
+			doc:  `{"version":1,"tree":{"parallel":[]}}`,
+			want: "parallel: empty array",
+		},
+		{
+			name: "name on composition",
+			doc:  `{"version":1,"tree":{"serial":[{"exec":["x"],"name":"x"}],"name":"oops"}}`,
+			want: "name: not allowed on serial composition",
+		},
+		{
+			name: "paths on composition",
+			doc:  `{"version":1,"tree":{"parallel":[{"exec":["x"],"name":"x"}],"paths":["."]}}`,
+			want: "paths: not allowed on parallel composition",
+		},
+		{
+			name: "paths empty array",
+			doc:  `{"version":1,"tree":{"exec":["x"],"name":"x","paths":[]}}`,
+			want: "paths: empty array",
+		},
+		{
+			name: "paths with empty entry",
+			doc:  `{"version":1,"tree":{"exec":["x"],"name":"x","paths":[""]}}`,
+			want: "paths[0]: empty path",
+		},
+		{
+			name: "nested unknown kind not allowed",
+			doc:  `{"version":1,"tree":{"serial":[{"exec":["x"],"name":"x","serial":[]}]}}`,
+			want: "expected exactly one of",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseExecJSON(strings.NewReader(tc.doc))
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+// markerScript returns a shell command that appends a token to a file.
+// Portable across platforms used in CI (linux, darwin, windows).
+func markerScript(t *testing.T, file, token string) []string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		return []string{"cmd", "/C", fmt.Sprintf(`echo %s >> %s`, token, file)}
+	}
+	return []string{"sh", "-c", fmt.Sprintf("printf '%%s\\n' %q >> %q", token, file)}
+}
+
+// readMarkers returns the lines from a marker file (or nil if it does not exist).
+func readMarkers(t *testing.T, file string) []string {
+	t.Helper()
+	data, err := os.ReadFile(file)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatal(err)
+	}
+	var out []string
+	for line := range strings.SplitSeq(strings.TrimRight(string(data), "\n\r"), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+func TestRunExecJSON_SerialOrder(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "out.txt")
+
+	doc := fmt.Sprintf(`{
+		"version": 1,
+		"tree": {
+			"serial": [
+				{"exec": %s, "name": "a"},
+				{"exec": %s, "name": "b"},
+				{"exec": %s, "name": "c"}
+			]
+		}
+	}`,
+		mustJSON(t, markerScript(t, marker, "a")),
+		mustJSON(t, markerScript(t, marker, "b")),
+		mustJSON(t, markerScript(t, marker, "c")),
+	)
+
+	ctx, stdout, _ := execJSONTestCtx(t)
+	if err := runExecJSON(ctx, strings.NewReader(doc)); err != nil {
+		t.Fatalf("runExecJSON: %v\nstdout: %s", err, stdout.String())
+	}
+
+	got := readMarkers(t, marker)
+	want := []string{"a", "b", "c"}
+	if !slices.Equal(got, want) {
+		t.Errorf("markers = %v, want %v\nstdout: %s", got, want, stdout.String())
+	}
+
+	// Headers should appear for each task in stdout.
+	for _, name := range want {
+		if !strings.Contains(stdout.String(), ":: "+name) {
+			t.Errorf("expected stdout to contain task header for %q, got:\n%s", name, stdout.String())
+		}
+	}
+}
+
+func TestRunExecJSON_ParallelRunsAll(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "out.txt")
+
+	doc := fmt.Sprintf(`{
+		"version": 1,
+		"tree": {
+			"parallel": [
+				{"exec": %s, "name": "a"},
+				{"exec": %s, "name": "b"},
+				{"exec": %s, "name": "c"}
+			]
+		}
+	}`,
+		mustJSON(t, markerScript(t, marker, "a")),
+		mustJSON(t, markerScript(t, marker, "b")),
+		mustJSON(t, markerScript(t, marker, "c")),
+	)
+
+	ctx, _, _ := execJSONTestCtx(t)
+	if err := runExecJSON(ctx, strings.NewReader(doc)); err != nil {
+		t.Fatalf("runExecJSON: %v", err)
+	}
+
+	got := readMarkers(t, marker)
+	sort.Strings(got)
+	want := []string{"a", "b", "c"}
+	if !slices.Equal(got, want) {
+		t.Errorf("markers = %v, want all of %v", got, want)
+	}
+}
+
+func TestRunExecJSON_TaskFailureReturnsError(t *testing.T) {
+	doc := `{
+		"version": 1,
+		"tree": {
+			"serial": [
+				{"exec": ["sh", "-c", "exit 1"], "name": "fail"}
+			]
+		}
+	}`
+	if runtime.GOOS == "windows" {
+		doc = `{
+			"version": 1,
+			"tree": {
+				"serial": [
+					{"exec": ["cmd", "/C", "exit 1"], "name": "fail"}
+				]
+			}
+		}`
+	}
+	ctx, _, _ := execJSONTestCtx(t)
+	err := runExecJSON(ctx, strings.NewReader(doc))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestRunExecJSON_ValidationErrorEmitsJSONOnStderr(t *testing.T) {
+	doc := `{"version":1,"tree":{}}`
+	ctx, _, stderr := execJSONTestCtx(t)
+	err := runExecJSON(ctx, strings.NewReader(doc))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var obj map[string]string
+	if jerr := json.Unmarshal(bytes.TrimSpace(stderr.Bytes()), &obj); jerr != nil {
+		t.Fatalf("stderr is not JSON: %v\n%s", jerr, stderr.String())
+	}
+	if obj["error"] == "" {
+		t.Errorf("expected error field, got %v", obj)
+	}
+}
+
+func TestRunExecJSON_MultiPathHeaders(t *testing.T) {
+	// Use a no-op task that records the path it ran at via the context.
+	// We replace the closure post-build to avoid invoking real shells.
+	doc := `{"version":1,"tree":{"exec":["echo","x"],"name":"multi","paths":["a","b"]}}`
+
+	root, err := parseExecJSON(strings.NewReader(doc))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var nodes []taskNodeInfo
+	tree, err := buildRunnable(root.Tree, &nodes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 task node, got %d", len(nodes))
+	}
+	var paths []string
+	nodes[0].task.Do = func(ctx context.Context) error {
+		paths = append(paths, pkrun.PathFromContext(ctx))
+		return nil
+	}
+	plan := buildPlanFromJSON(tree, nodes)
+
+	ctx, stdout, _ := execJSONTestCtx(t)
+	ctx = context.WithValue(ctx, ctxkey.Plan{}, plan)
+	ctx = withExecutionTracker(ctx, newExecutionTracker())
+	if err := tree.run(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if !slices.Equal(paths, []string{"a", "b"}) {
+		t.Errorf("paths visited = %v, want [a b]", paths)
+	}
+	// Per-path headers should appear in stdout.
+	for _, p := range []string{"a", "b"} {
+		want := fmt.Sprintf(":: multi [%s]", p)
+		if !strings.Contains(stdout.String(), want) {
+			t.Errorf("expected header %q, got:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestBuildRunnable_SingleTaskAtRootIsBareTask(t *testing.T) {
+	doc := `{"version":1,"tree":{"exec":["echo","x"],"name":"x"}}`
+	root, err := parseExecJSON(strings.NewReader(doc))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var nodes []taskNodeInfo
+	r, err := buildRunnable(root.Tree, &nodes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := r.(*Task); !ok {
+		t.Errorf("expected *Task for single-task root, got %T", r)
+	}
+	if len(nodes) != 1 || nodes[0].name != "x" {
+		t.Errorf("unexpected taskNodes: %+v", nodes)
+	}
+}
+
+func TestBuildRunnable_MultiPathWrapsInPathFilter(t *testing.T) {
+	doc := `{"version":1,"tree":{"exec":["echo","x"],"name":"x","paths":["a","b"]}}`
+	root, err := parseExecJSON(strings.NewReader(doc))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var nodes []taskNodeInfo
+	r, err := buildRunnable(root.Tree, &nodes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pf, ok := r.(*pathFilter)
+	if !ok {
+		t.Fatalf("expected *pathFilter, got %T", r)
+	}
+	if !slices.Equal(pf.resolvedPaths, []string{"a", "b"}) {
+		t.Errorf("resolvedPaths = %v, want [a b]", pf.resolvedPaths)
+	}
+}
+
+func TestBuildPlanFromJSON_PopulatesPathMappings(t *testing.T) {
+	doc := `{"version":1,"tree":{"serial":[
+		{"exec":["echo","a"],"name":"a","paths":["x"]},
+		{"exec":["echo","b"],"name":"b"}
+	]}}`
+	root, err := parseExecJSON(strings.NewReader(doc))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var nodes []taskNodeInfo
+	tree, err := buildRunnable(root.Tree, &nodes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := buildPlanFromJSON(tree, nodes)
+	if got := plan.pathMappings["a"].resolvedPaths; !slices.Equal(got, []string{"x"}) {
+		t.Errorf("a paths = %v, want [x]", got)
+	}
+	if got := plan.pathMappings["b"].resolvedPaths; !slices.Equal(got, []string{"."}) {
+		t.Errorf("b paths = %v, want [.]", got)
+	}
+	if inst := plan.taskInstanceByName("a"); inst == nil {
+		t.Error("taskInstanceByName(a) returned nil")
+	}
+}
+
+func TestEmitInvocationJSON_FullTree(t *testing.T) {
+	task := &Task{Name: "lint", Usage: "lint", Do: func(_ context.Context) error { return nil }}
+	cfg := &Config{Auto: Serial(task)}
+	plan, err := newPlan(cfg, "/tmp", []string{"."})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := emitInvocationJSON(plan, "", &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("emitted JSON does not parse: %v\n%s", err, buf.String())
+	}
+	if doc["version"].(float64) != 1 {
+		t.Errorf("version = %v, want 1", doc["version"])
+	}
+	tree, _ := doc["tree"].(map[string]any)
+	if tree == nil {
+		t.Fatalf("missing tree: %s", buf.String())
+	}
+	if _, ok := tree["serial"]; !ok {
+		t.Errorf("expected serial kind key in tree, got %v", tree)
+	}
+}
+
+func TestEmitInvocationJSON_SingleTask(t *testing.T) {
+	task := &Task{Name: "lint", Usage: "lint", Do: func(_ context.Context) error { return nil }}
+	cfg := &Config{Auto: Serial(task)}
+	plan, err := newPlan(cfg, "/tmp", []string{"."})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := emitInvocationJSON(plan, "lint", &buf); err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatal(err)
+	}
+	tree, _ := doc["tree"].(map[string]any)
+	if tree["name"] != "lint" {
+		t.Errorf("name = %v, want lint", tree["name"])
+	}
+	paths, _ := tree["paths"].([]any)
+	if len(paths) != 1 || paths[0] != "." {
+		t.Errorf("paths = %v, want [.]", paths)
+	}
+}
+
+func TestEmitInvocationJSON_UnknownTask(t *testing.T) {
+	plan, err := newPlan(&Config{Auto: nil}, "/tmp", []string{"."})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := emitInvocationJSON(plan, "missing", &buf); err == nil {
+		t.Error("expected error for unknown task")
+	}
+}
+
+func TestExecJSONSchema_IsValidJSON(t *testing.T) {
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(execJSONSchema), &doc); err != nil {
+		t.Fatalf("execJSONSchema is not valid JSON: %v", err)
+	}
+	if _, ok := doc["definitions"]; !ok {
+		t.Error("schema missing definitions block")
+	}
+}
+
+func TestRunExecJSON_DuplicateNameDeduplicatesAtSamePath(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "out.txt")
+
+	doc := fmt.Sprintf(`{
+		"version": 1,
+		"tree": {
+			"serial": [
+				{"exec": %s, "name": "same"},
+				{"exec": %s, "name": "same"}
+			]
+		}
+	}`,
+		mustJSON(t, markerScript(t, marker, "first")),
+		mustJSON(t, markerScript(t, marker, "second")),
+	)
+
+	ctx, _, _ := execJSONTestCtx(t)
+	if err := runExecJSON(ctx, strings.NewReader(doc)); err != nil {
+		t.Fatalf("runExecJSON: %v", err)
+	}
+
+	got := readMarkers(t, marker)
+	if len(got) != 1 || got[0] != "first" {
+		t.Errorf("expected only first marker (dedup), got %v", got)
+	}
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}

--- a/pk/execjson_test.go
+++ b/pk/execjson_test.go
@@ -32,11 +32,12 @@ func TestParseExecJSON_Valid(t *testing.T) {
 	doc := `{
 		"version": 1,
 		"tree": {
-			"serial": [
-				{"exec": ["echo", "a"], "name": "step-a"},
-				{"parallel": [
-					{"exec": ["echo", "b"], "name": "step-b"},
-					{"exec": ["echo", "c"], "name": "step-c"}
+			"type": "serial",
+			"children": [
+				{"type": "command", "argv": ["echo", "a"], "name": "step-a"},
+				{"type": "parallel", "children": [
+					{"type": "command", "argv": ["echo", "b"], "name": "step-b"},
+					{"type": "task", "name": "go-test"}
 				]}
 			]
 		}
@@ -48,7 +49,7 @@ func TestParseExecJSON_Valid(t *testing.T) {
 	if root.Version != 1 {
 		t.Errorf("version = %d, want 1", root.Version)
 	}
-	if root.Tree == nil || len(root.Tree.Serial) != 2 {
+	if root.Tree == nil || len(root.Tree.Children) != 2 {
 		t.Errorf("expected serial with 2 children, got %+v", root.Tree)
 	}
 }
@@ -61,12 +62,12 @@ func TestParseExecJSON_Errors(t *testing.T) {
 	}{
 		{
 			name: "unknown top-level field",
-			doc:  `{"version":1,"tree":{"exec":["x"],"name":"x"},"extra":1}`,
+			doc:  `{"version":1,"tree":{"type":"command","argv":["x"],"name":"x"},"extra":1}`,
 			want: `unknown field "extra"`,
 		},
 		{
 			name: "unknown nested field",
-			doc:  `{"version":1,"tree":{"exec":["x"],"name":"x","bogus":1}}`,
+			doc:  `{"version":1,"tree":{"type":"command","argv":["x"],"name":"x","bogus":1}}`,
 			want: `unknown field "bogus"`,
 		},
 		{
@@ -76,82 +77,92 @@ func TestParseExecJSON_Errors(t *testing.T) {
 		},
 		{
 			name: "unsupported version",
-			doc:  `{"version":2,"tree":{"exec":["x"],"name":"x"}}`,
+			doc:  `{"version":2,"tree":{"type":"command","argv":["x"],"name":"x"}}`,
 			want: "version: unsupported",
 		},
 		{
-			name: "version zero (absent)",
-			doc:  `{"tree":{"exec":["x"],"name":"x"}}`,
+			name: "version zero absent",
+			doc:  `{"tree":{"type":"command","argv":["x"],"name":"x"}}`,
 			want: "version: unsupported value 0",
 		},
 		{
-			name: "no kind key",
+			name: "missing type",
 			doc:  `{"version":1,"tree":{"name":"x"}}`,
-			want: "expected one of: exec, serial, parallel",
+			want: "tree.type: required",
 		},
 		{
-			name: "two kind keys",
-			doc:  `{"version":1,"tree":{"exec":["x"],"serial":[]}}`,
-			want: "expected exactly one of",
+			name: "unknown type",
+			doc:  `{"version":1,"tree":{"type":"shell","name":"x"}}`,
+			want: `tree.type: unsupported value "shell"`,
 		},
 		{
-			name: "exec empty",
-			doc:  `{"version":1,"tree":{"exec":[],"name":"x"}}`,
-			want: "exec: empty array",
+			name: "command argv empty",
+			doc:  `{"version":1,"tree":{"type":"command","argv":[],"name":"x"}}`,
+			want: "argv: empty array",
 		},
 		{
-			name: "exec missing name",
-			doc:  `{"version":1,"tree":{"exec":["x"]}}`,
-			want: "name: required",
+			name: "command missing name",
+			doc:  `{"version":1,"tree":{"type":"command","argv":["x"]}}`,
+			want: "name: required for command nodes",
+		},
+		{
+			name: "task missing name",
+			doc:  `{"version":1,"tree":{"type":"task"}}`,
+			want: "name: required for task nodes",
 		},
 		{
 			name: "serial empty",
-			doc:  `{"version":1,"tree":{"serial":[]}}`,
-			want: "serial: empty array",
+			doc:  `{"version":1,"tree":{"type":"serial","children":[]}}`,
+			want: "children: empty array",
 		},
 		{
 			name: "parallel empty",
-			doc:  `{"version":1,"tree":{"parallel":[]}}`,
-			want: "parallel: empty array",
+			doc:  `{"version":1,"tree":{"type":"parallel","children":[]}}`,
+			want: "children: empty array",
 		},
 		{
 			name: "name on composition",
-			doc:  `{"version":1,"tree":{"serial":[{"exec":["x"],"name":"x"}],"name":"oops"}}`,
-			want: "name: not allowed on serial composition",
+			doc:  `{"version":1,"tree":{"type":"serial","children":[{"type":"command","argv":["x"],"name":"x"}],"name":"oops"}}`,
+			want: "name: not allowed on serial nodes",
 		},
 		{
 			name: "paths on composition",
-			doc:  `{"version":1,"tree":{"parallel":[{"exec":["x"],"name":"x"}],"paths":["."]}}`,
-			want: "paths: not allowed on parallel composition",
+			doc:  `{"version":1,"tree":{"type":"parallel","children":[{"type":"command","argv":["x"],"name":"x"}],"paths":["."]}}`,
+			want: "paths: not allowed on parallel nodes",
+		},
+		{
+			name: "argv on task",
+			doc:  `{"version":1,"tree":{"type":"task","name":"x","argv":["x"]}}`,
+			want: "argv: not allowed on task nodes",
+		},
+		{
+			name: "children on command",
+			doc:  `{"version":1,"tree":{"type":"command","name":"x","argv":["x"],"children":[]}}`,
+			want: "children: not allowed on command nodes",
 		},
 		{
 			name: "paths empty array",
-			doc:  `{"version":1,"tree":{"exec":["x"],"name":"x","paths":[]}}`,
+			doc:  `{"version":1,"tree":{"type":"command","argv":["x"],"name":"x","paths":[]}}`,
 			want: "paths: empty array",
 		},
 		{
 			name: "paths with empty entry",
-			doc:  `{"version":1,"tree":{"exec":["x"],"name":"x","paths":[""]}}`,
+			doc:  `{"version":1,"tree":{"type":"command","argv":["x"],"name":"x","paths":[""]}}`,
 			want: "paths[0]: empty path",
 		},
 		{
-			name: "nested unknown kind not allowed",
-			doc:  `{"version":1,"tree":{"serial":[{"exec":["x"],"name":"x","serial":[]}]}}`,
-			want: "expected exactly one of",
-		},
-		{
-			name: "exec as string instead of array",
-			doc:  `{"version":1,"tree":{"exec":"echo hi","name":"x"}}`,
-			want: "tree.exec: expected array of strings, got string",
+			name: "argv as string instead of array",
+			doc:  `{"version":1,"tree":{"type":"command","argv":"echo hi","name":"x"}}`,
+			want: "tree.argv: expected array of strings, got string",
 		},
 		{
 			name: "paths as string instead of array",
-			doc:  `{"version":1,"tree":{"exec":["x"],"name":"x","paths":"."}}`,
+			doc:  `{"version":1,"tree":{"type":"command","argv":["x"],"name":"x","paths":"."}}`,
 			want: "tree.paths: expected array of strings, got string",
 		},
 		{
 			name: "version as string instead of integer",
-			doc:  `{"version":"1","tree":{"exec":["x"],"name":"x"}}`,
+			doc:  `{"version":"1","tree":{"type":"command","argv":["x"],"name":"x"}}`,
 			want: "version: expected integer, got string",
 		},
 		{
@@ -160,13 +171,13 @@ func TestParseExecJSON_Errors(t *testing.T) {
 			want: "tree: expected object, got string",
 		},
 		{
-			name: "serial as object instead of array",
-			doc:  `{"version":1,"tree":{"serial":{}}}`,
-			want: "tree.serial: expected array of nodes, got object",
+			name: "children as object instead of array",
+			doc:  `{"version":1,"tree":{"type":"serial","children":{}}}`,
+			want: "tree.children: expected array of nodes, got object",
 		},
 		{
 			name: "syntax error",
-			doc:  `{"version":1,"tree":{"exec":["x"]`,
+			doc:  `{"version":1,"tree":{"type":"command","argv":["x"]`,
 			want: "unexpected EOF",
 		},
 	}
@@ -190,10 +201,10 @@ func markerScript(t *testing.T, file, token string) []string {
 	if runtime.GOOS == "windows" {
 		return []string{"cmd", "/C", fmt.Sprintf(`echo %s >> %s`, token, file)}
 	}
-	return []string{"sh", "-c", fmt.Sprintf("printf '%%s\\n' %q >> %q", token, file)}
+	return []string{"sh", "-c", fmt.Sprintf("printf '%%s\n' %q >> %q", token, file)}
 }
 
-// readMarkers returns the lines from a marker file (or nil if it does not exist).
+// readMarkers returns the lines from a marker file, or nil if it does not exist.
 func readMarkers(t *testing.T, file string) []string {
 	t.Helper()
 	data, err := os.ReadFile(file)
@@ -220,10 +231,11 @@ func TestRunExecJSON_SerialOrder(t *testing.T) {
 	doc := fmt.Sprintf(`{
 		"version": 1,
 		"tree": {
-			"serial": [
-				{"exec": %s, "name": "a"},
-				{"exec": %s, "name": "b"},
-				{"exec": %s, "name": "c"}
+			"type": "serial",
+			"children": [
+				{"type": "command", "argv": %s, "name": "a"},
+				{"type": "command", "argv": %s, "name": "b"},
+				{"type": "command", "argv": %s, "name": "c"}
 			]
 		}
 	}`,
@@ -242,8 +254,6 @@ func TestRunExecJSON_SerialOrder(t *testing.T) {
 	if !slices.Equal(got, want) {
 		t.Errorf("markers = %v, want %v\nstdout: %s", got, want, stdout.String())
 	}
-
-	// Headers should appear for each task in stdout.
 	for _, name := range want {
 		if !strings.Contains(stdout.String(), ":: "+name) {
 			t.Errorf("expected stdout to contain task header for %q, got:\n%s", name, stdout.String())
@@ -258,10 +268,11 @@ func TestRunExecJSON_ParallelRunsAll(t *testing.T) {
 	doc := fmt.Sprintf(`{
 		"version": 1,
 		"tree": {
-			"parallel": [
-				{"exec": %s, "name": "a"},
-				{"exec": %s, "name": "b"},
-				{"exec": %s, "name": "c"}
+			"type": "parallel",
+			"children": [
+				{"type": "command", "argv": %s, "name": "a"},
+				{"type": "command", "argv": %s, "name": "b"},
+				{"type": "command", "argv": %s, "name": "c"}
 			]
 		}
 	}`,
@@ -284,23 +295,9 @@ func TestRunExecJSON_ParallelRunsAll(t *testing.T) {
 }
 
 func TestRunExecJSON_TaskFailureReturnsError(t *testing.T) {
-	doc := `{
-		"version": 1,
-		"tree": {
-			"serial": [
-				{"exec": ["sh", "-c", "exit 1"], "name": "fail"}
-			]
-		}
-	}`
+	doc := `{"version":1,"tree":{"type":"command","argv":["sh","-c","exit 1"],"name":"fail"}}`
 	if runtime.GOOS == "windows" {
-		doc = `{
-			"version": 1,
-			"tree": {
-				"serial": [
-					{"exec": ["cmd", "/C", "exit 1"], "name": "fail"}
-				]
-			}
-		}`
+		doc = `{"version":1,"tree":{"type":"command","argv":["cmd","/C","exit 1"],"name":"fail"}}`
 	}
 	ctx, _, _ := execJSONTestCtx(t)
 	err := runExecJSON(ctx, strings.NewReader(doc))
@@ -326,16 +323,14 @@ func TestRunExecJSON_ValidationErrorEmitsJSONOnStderr(t *testing.T) {
 }
 
 func TestRunExecJSON_MultiPathHeaders(t *testing.T) {
-	// Use a no-op task that records the path it ran at via the context.
-	// We replace the closure post-build to avoid invoking real shells.
-	doc := `{"version":1,"tree":{"exec":["echo","x"],"name":"multi","paths":["a","b"]}}`
+	doc := `{"version":1,"tree":{"type":"command","argv":["echo","x"],"name":"multi","paths":["a","b"]}}`
 
 	root, err := parseExecJSON(strings.NewReader(doc))
 	if err != nil {
 		t.Fatal(err)
 	}
 	var nodes []taskNodeInfo
-	tree, err := buildRunnable(root.Tree, &nodes)
+	tree, err := buildRunnable(root.Tree, &nodes, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -347,7 +342,7 @@ func TestRunExecJSON_MultiPathHeaders(t *testing.T) {
 		paths = append(paths, pkrun.PathFromContext(ctx))
 		return nil
 	}
-	plan := buildPlanFromJSON(tree, nodes)
+	plan := buildPlanFromJSON(tree, nodes, nil)
 
 	ctx, stdout, _ := execJSONTestCtx(t)
 	ctx = context.WithValue(ctx, ctxkey.Plan{}, plan)
@@ -359,7 +354,6 @@ func TestRunExecJSON_MultiPathHeaders(t *testing.T) {
 	if !slices.Equal(paths, []string{"a", "b"}) {
 		t.Errorf("paths visited = %v, want [a b]", paths)
 	}
-	// Per-path headers should appear in stdout.
 	for _, p := range []string{"a", "b"} {
 		want := fmt.Sprintf(":: multi [%s]", p)
 		if !strings.Contains(stdout.String(), want) {
@@ -368,33 +362,33 @@ func TestRunExecJSON_MultiPathHeaders(t *testing.T) {
 	}
 }
 
-func TestBuildRunnable_SingleTaskAtRootIsBareTask(t *testing.T) {
-	doc := `{"version":1,"tree":{"exec":["echo","x"],"name":"x"}}`
+func TestBuildRunnable_SingleCommandAtRootIsBareTask(t *testing.T) {
+	doc := `{"version":1,"tree":{"type":"command","argv":["echo","x"],"name":"x"}}`
 	root, err := parseExecJSON(strings.NewReader(doc))
 	if err != nil {
 		t.Fatal(err)
 	}
 	var nodes []taskNodeInfo
-	r, err := buildRunnable(root.Tree, &nodes)
+	r, err := buildRunnable(root.Tree, &nodes, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if _, ok := r.(*Task); !ok {
-		t.Errorf("expected *Task for single-task root, got %T", r)
+		t.Errorf("expected *Task for single command at root, got %T", r)
 	}
 	if len(nodes) != 1 || nodes[0].name != "x" {
 		t.Errorf("unexpected taskNodes: %+v", nodes)
 	}
 }
 
-func TestBuildRunnable_MultiPathWrapsInPathFilter(t *testing.T) {
-	doc := `{"version":1,"tree":{"exec":["echo","x"],"name":"x","paths":["a","b"]}}`
+func TestBuildRunnable_MultiPathWrapsCommandInPathFilter(t *testing.T) {
+	doc := `{"version":1,"tree":{"type":"command","argv":["echo","x"],"name":"x","paths":["a","b"]}}`
 	root, err := parseExecJSON(strings.NewReader(doc))
 	if err != nil {
 		t.Fatal(err)
 	}
 	var nodes []taskNodeInfo
-	r, err := buildRunnable(root.Tree, &nodes)
+	r, err := buildRunnable(root.Tree, &nodes, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -407,21 +401,67 @@ func TestBuildRunnable_MultiPathWrapsInPathFilter(t *testing.T) {
 	}
 }
 
+func TestRunExecJSON_TaskReference(t *testing.T) {
+	var ran []string
+	task := &Task{Name: "lint", Usage: "lint", Do: func(ctx context.Context) error {
+		ran = append(ran, pkrun.PathFromContext(ctx))
+		return nil
+	}}
+	basePlan, err := newPlan(&Config{Auto: Serial(task)}, "/tmp", []string{"."})
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc := `{"version":1,"tree":{"type":"task","name":"lint","paths":["api"]}}`
+	ctx, stdout, _ := execJSONTestCtx(t)
+	ctx = context.WithValue(ctx, ctxkey.Plan{}, basePlan)
+	if err := runExecJSON(ctx, strings.NewReader(doc)); err != nil {
+		t.Fatalf("runExecJSON: %v", err)
+	}
+	if !slices.Equal(ran, []string{"api"}) {
+		t.Errorf("paths visited = %v, want [api]", ran)
+	}
+	if !strings.Contains(stdout.String(), ":: lint [api]") {
+		t.Errorf("expected task header for path, got:\n%s", stdout.String())
+	}
+}
+
+func TestBuildPlanFromJSON_TaskReferencePathsOverrideBasePlan(t *testing.T) {
+	task := &Task{Name: "lint", Usage: "lint", Do: func(_ context.Context) error { return nil }}
+	basePlan, err := newPlan(&Config{Auto: Serial(task)}, "/tmp", []string{"."})
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc := `{"version":1,"tree":{"type":"task","name":"lint","paths":["api"]}}`
+	root, err := parseExecJSON(strings.NewReader(doc))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var nodes []taskNodeInfo
+	tree, err := buildRunnable(root.Tree, &nodes, basePlan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := buildPlanFromJSON(tree, nodes, basePlan)
+	if got := plan.pathMappings["lint"].resolvedPaths; !slices.Equal(got, []string{"api"}) {
+		t.Errorf("lint paths = %v, want [api]", got)
+	}
+}
+
 func TestBuildPlanFromJSON_PopulatesPathMappings(t *testing.T) {
-	doc := `{"version":1,"tree":{"serial":[
-		{"exec":["echo","a"],"name":"a","paths":["x"]},
-		{"exec":["echo","b"],"name":"b"}
+	doc := `{"version":1,"tree":{"type":"serial","children":[
+		{"type":"command","argv":["echo","a"],"name":"a","paths":["x"]},
+		{"type":"command","argv":["echo","b"],"name":"b"}
 	]}}`
 	root, err := parseExecJSON(strings.NewReader(doc))
 	if err != nil {
 		t.Fatal(err)
 	}
 	var nodes []taskNodeInfo
-	tree, err := buildRunnable(root.Tree, &nodes)
+	tree, err := buildRunnable(root.Tree, &nodes, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	plan := buildPlanFromJSON(tree, nodes)
+	plan := buildPlanFromJSON(tree, nodes, nil)
 	if got := plan.pathMappings["a"].resolvedPaths; !slices.Equal(got, []string{"x"}) {
 		t.Errorf("a paths = %v, want [x]", got)
 	}
@@ -457,8 +497,11 @@ func TestEmitInvocationJSON_FullTree(t *testing.T) {
 	if tree == nil {
 		t.Fatalf("missing tree: %s", buf.String())
 	}
-	if _, ok := tree["serial"]; !ok {
-		t.Errorf("expected serial kind key in tree, got %v", tree)
+	if tree["type"] != "serial" {
+		t.Errorf("expected serial type in tree, got %v", tree)
+	}
+	if _, ok := tree["children"]; !ok {
+		t.Errorf("expected children in tree, got %v", tree)
 	}
 }
 
@@ -479,6 +522,9 @@ func TestEmitInvocationJSON_SingleTask(t *testing.T) {
 		t.Fatal(err)
 	}
 	tree, _ := doc["tree"].(map[string]any)
+	if tree["type"] != "task" {
+		t.Errorf("type = %v, want task", tree["type"])
+	}
 	if tree["name"] != "lint" {
 		t.Errorf("name = %v, want lint", tree["name"])
 	}
@@ -516,9 +562,10 @@ func TestRunExecJSON_DuplicateNameDeduplicatesAtSamePath(t *testing.T) {
 	doc := fmt.Sprintf(`{
 		"version": 1,
 		"tree": {
-			"serial": [
-				{"exec": %s, "name": "same"},
-				{"exec": %s, "name": "same"}
+			"type": "serial",
+			"children": [
+				{"type": "command", "argv": %s, "name": "same"},
+				{"type": "command", "argv": %s, "name": "same"}
 			]
 		}
 	}`,

--- a/pk/execjson_test.go
+++ b/pk/execjson_test.go
@@ -482,7 +482,8 @@ func TestEmitInvocationJSON_FullTree(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := emitInvocationJSON(plan, "", &buf); err != nil {
+	ctx := context.Background()
+	if err := emitInvocationJSON(ctx, plan, "", &buf); err != nil {
 		t.Fatal(err)
 	}
 
@@ -514,7 +515,8 @@ func TestEmitInvocationJSON_SingleTask(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := emitInvocationJSON(plan, "lint", &buf); err != nil {
+	ctx := context.Background()
+	if err := emitInvocationJSON(ctx, plan, "lint", &buf); err != nil {
 		t.Fatal(err)
 	}
 	var doc map[string]any
@@ -540,8 +542,48 @@ func TestEmitInvocationJSON_UnknownTask(t *testing.T) {
 		t.Fatal(err)
 	}
 	var buf bytes.Buffer
-	if err := emitInvocationJSON(plan, "missing", &buf); err == nil {
+	ctx := context.Background()
+	if err := emitInvocationJSON(ctx, plan, "missing", &buf); err == nil {
 		t.Error("expected error for unknown task")
+	}
+}
+
+func TestEmitInvocationJSON_IncludesGlobalOptions(t *testing.T) {
+	task := &Task{Name: "lint", Usage: "lint", Do: func(_ context.Context) error { return nil }}
+	plan, err := newPlan(&Config{Auto: Serial(task)}, "/tmp", []string{"."})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, ctxkey.Verbose{}, true)
+	ctx = context.WithValue(ctx, ctxkey.Serial{}, true)
+	ctx = context.WithValue(ctx, ctxkey.GitDiff{}, true)
+	ctx = context.WithValue(ctx, ctxkey.CommitsCheck{}, true)
+
+	var buf bytes.Buffer
+	if err := emitInvocationJSON(ctx, plan, "lint", &buf); err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		Options jsonOptions `json:"options"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatal(err)
+	}
+	if !doc.Options.Verbose || !doc.Options.Serial || !doc.Options.GitDiff || !doc.Options.Commits {
+		t.Errorf("options = %+v, want all true", doc.Options)
+	}
+}
+
+func TestRunExecJSON_AppliesGlobalOptions(t *testing.T) {
+	doc := `{"version":1,"options":{"verbose":true,"serial":true,"gitdiff":true,"commits":true},"tree":{"type":"command","argv":["echo","x"],"name":"x"}}`
+	root, err := parseExecJSON(strings.NewReader(doc))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := contextWithJSONOptions(context.Background(), root.Options)
+	if !pkrun.Verbose(ctx) || !serialFromContext(ctx) || !gitDiffEnabled(ctx) || !commitsCheckEnabled(ctx) {
+		t.Fatal("expected JSON options to be applied to context")
 	}
 }
 

--- a/pk/execjson_test.go
+++ b/pk/execjson_test.go
@@ -264,7 +264,9 @@ func TestRunExecJSON_SerialOrder(t *testing.T) {
 
 func TestRunExecJSON_ParallelRunsAll(t *testing.T) {
 	dir := t.TempDir()
-	marker := filepath.Join(dir, "out.txt")
+	markerA := filepath.Join(dir, "a.txt")
+	markerB := filepath.Join(dir, "b.txt")
+	markerC := filepath.Join(dir, "c.txt")
 
 	doc := fmt.Sprintf(`{
 		"version": 1,
@@ -277,9 +279,9 @@ func TestRunExecJSON_ParallelRunsAll(t *testing.T) {
 			]
 		}
 	}`,
-		mustJSON(t, markerScript(t, marker, "a")),
-		mustJSON(t, markerScript(t, marker, "b")),
-		mustJSON(t, markerScript(t, marker, "c")),
+		mustJSON(t, markerScript(t, markerA, "a")),
+		mustJSON(t, markerScript(t, markerB, "b")),
+		mustJSON(t, markerScript(t, markerC, "c")),
 	)
 
 	ctx, _, _ := execJSONTestCtx(t)
@@ -287,7 +289,8 @@ func TestRunExecJSON_ParallelRunsAll(t *testing.T) {
 		t.Fatalf("runExecJSON: %v", err)
 	}
 
-	got := readMarkers(t, marker)
+	got := append(readMarkers(t, markerA), readMarkers(t, markerB)...)
+	got = append(got, readMarkers(t, markerC)...)
 	sort.Strings(got)
 	want := []string{"a", "b", "c"}
 	if !slices.Equal(got, want) {

--- a/pk/internal/ctxkey/ctxkey.go
+++ b/pk/internal/ctxkey/ctxkey.go
@@ -13,6 +13,7 @@ type (
 	AutoExec       struct{} // Auto execution mode.
 	TaskFlags      struct{} // Resolved task flag values.
 	CLIFlags       struct{} // CLI-provided flag overrides.
+	TaskArgs       struct{} // Positional args remaining after task flag parsing.
 	NoticePatterns struct{} // Custom notice patterns.
 	Plan           struct{} // Execution plan.
 	Tracker        struct{} // Execution tracker.


### PR DESCRIPTION
## Why?

Make Pocket easier for LLMs and agents to inspect, compose, and execute task trees without writing Go code.

## What?

- Add `pok exec` to read a versioned JSON task tree from stdin and execute it through the existing Pocket engine.
- Add `--json` / `-j` to emit executable JSON for the full Auto tree or a single task, e.g. `./pok --json go-test | ./pok exec`.
- Use an explicit LLM-friendly JSON schema with typed nodes: `task`, `command`, `serial`, and `parallel`.
- Serialize global execution options (`verbose`, `serial`, `gitdiff`, `commits`) so invocations like `./pok --json -g go-test | ./pok exec` preserve post-actions.
- Let `pok plan` render JSON trees from stdin or a file without executing them.
- Add JSON Schema output via `pok exec --schema`, tests, and documentation.

## Notes

JSON `task` nodes reference existing Pocket tasks; JSON `command` nodes run raw argv commands. Both paths build a `Plan`/Runnable tree and reuse the existing execution engine, including deduplication, output buffering, paths, and post-actions.
