### PR TITLE
fix(pk): union paths when a task is referenced in multiple scopes

### DIFF
--- a/.claude/skills/pocket-engine/INTERNALS.md
+++ b/.claude/skills/pocket-engine/INTERNALS.md
@@ -33,7 +33,11 @@ type taskInstance struct {
 2. **Collect tasks** — `taskCollector` traverses the composition tree. For each
    `pathFilter` encountered, it pushes scope (include/exclude patterns, flags,
    context values, name suffix) onto a stack. For each `Task`, it creates a
-   `taskInstance` with the accumulated scope.
+   `taskInstance` with the accumulated scope. Repeat occurrences of the same
+   (task, suffix) pair merge into the existing instance: resolved paths are
+   unioned (in `taskInstances` and `pathMappings` alike, so auto execution and
+   direct invocation agree), and conflicting flag overrides across scopes fail
+   plan building.
 
 3. **Resolve paths** — For each task instance, paths are resolved against the
    cached directory list:

--- a/.pocket/go.mod
+++ b/.pocket/go.mod
@@ -1,6 +1,6 @@
 module pocket
 
-go 1.26.3
+go 1.26.4
 
 require github.com/fredrikaverpil/pocket v0.6.0
 

--- a/README.md
+++ b/README.md
@@ -210,8 +210,9 @@ pk.WithOptions(
 
 The same task at the same path only runs once per invocation, even if referenced
 multiple times in your composition tree. This makes it safe to compose shared
-dependencies without worrying about redundant work. Use `WithForceRun()` to
-bypass deduplication when needed.
+dependencies without worrying about redundant work. Referencing the same task
+under multiple path scopes runs it in the union of all scopes' paths. Use
+`WithForceRun()` to bypass deduplication when needed.
 
 ### Shim Scoping
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -836,6 +836,17 @@ pk.Serial(
 // Install runs once, not three times
 ```
 
+Referencing the same task under multiple path scopes runs it in the union of all
+scopes' paths, deduplicated per path:
+
+```go
+pk.Serial(
+    pk.WithOptions(Lint, pk.WithPath("svc-a")),
+    pk.WithOptions(Lint, pk.WithPath("svc-b")),
+)
+// Lint runs in svc-a and svc-b
+```
+
 Use `WithForceRun()` to bypass deduplication when needed:
 
 ```go
@@ -897,6 +908,13 @@ pk.WithOptions(
     pk.WithDetect(python.Detect()),
 )
 ```
+
+> [!NOTE]
+>
+> A task referenced from multiple scopes must resolve to the same flag overrides
+> in all of them — conflicting `WithFlags` values (including an override in one
+> scope but not another) fail plan building. Use `pk.WithNameSuffix` to create
+> distinct variants instead.
 
 **Creating custom options:** When building your own task packages, use
 `pk.WithFlags` to set task flags:

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -260,6 +260,12 @@ pk.WithOptions(python.Test, pk.WithNameSuffix("3.10"), pk.WithFlags(python.TestF
 Each variant has an **effective name** (base name + suffix). Variants are
 deduplicated separately, so `py-test:3.9` and `py-test:3.10` both run.
 
+A task (or variant) referenced from multiple scopes becomes a single instance
+that runs in the union of all scopes' paths. All scopes must agree on the task's
+flag overrides — conflicting `WithFlags` values (including an override in one
+scope but not another) fail plan building. Use `WithNameSuffix` to create
+distinct variants instead.
+
 ### Default Execution Path
 
 Tasks run at the repository root (`.`) by default. Use `WithPath` or
@@ -303,6 +309,8 @@ This means:
 
 - Same task at the same path runs only once
 - Same task at different paths runs once per path
+- Same task referenced from multiple scopes runs in the union of the scopes'
+  paths
 - Different variants (via `WithNameSuffix`) run separately
 
 **Global tasks** deduplicate by `baseName@.` only, ignoring the execution path.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fredrikaverpil/pocket
 
-go 1.26.3
+go 1.26.4
 
 require (
 	golang.org/x/sync v0.20.0

--- a/pk/e2e_test.go
+++ b/pk/e2e_test.go
@@ -598,3 +598,82 @@ func TestE2E_AutoExec_TaskScope(t *testing.T) {
 	want := []execRecord{{TaskName: "scoped", Path: "svc-a"}}
 	assert.DeepEqual(t, rec.records, want)
 }
+
+func TestE2E_AutoExec_TaskInMultipleScopes(t *testing.T) {
+	tmpDir := e2eSetup(t)
+	for _, d := range []string{"svc-a", "svc-b"} {
+		if err := os.MkdirAll(filepath.Join(tmpDir, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	rec := newRecorder()
+	task := rec.task("multi")
+
+	cfg := &Config{
+		Auto: Serial(
+			WithOptions(task, WithPath("svc-a")),
+			WithOptions(task, WithPath("svc-b")),
+		),
+	}
+	plan, err := newPublicPlan(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := e2eCtx(t, plan)
+	ctx = context.WithValue(ctx, ctxkey.AutoExec{}, true)
+	if err := cfg.Auto.run(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(rec.records) != 2 {
+		t.Fatalf("expected 2 records, got %d: %+v", len(rec.records), rec.records)
+	}
+	paths := map[string]bool{}
+	for _, r := range rec.records {
+		paths[r.Path] = true
+	}
+	if !paths["svc-a"] || !paths["svc-b"] {
+		t.Errorf("expected task to run in svc-a and svc-b, got %v", paths)
+	}
+}
+
+func TestE2E_ExecuteTask_MultipleScopes(t *testing.T) {
+	tmpDir := e2eSetup(t)
+	for _, d := range []string{"svc-a", "svc-b"} {
+		if err := os.MkdirAll(filepath.Join(tmpDir, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	rec := newRecorder()
+	task := rec.task("multi")
+
+	cfg := &Config{
+		Auto: Serial(
+			WithOptions(task, WithPath("svc-a")),
+			WithOptions(task, WithPath("svc-b")),
+		),
+	}
+	plan, err := newPublicPlan(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := e2eCtx(t, plan)
+	if err := ExecuteTask(ctx, "multi", plan); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(rec.records) != 2 {
+		t.Fatalf("expected 2 records, got %d: %+v", len(rec.records), rec.records)
+	}
+	paths := map[string]bool{}
+	for _, r := range rec.records {
+		paths[r.Path] = true
+	}
+	if !paths["svc-a"] || !paths["svc-b"] {
+		t.Errorf("expected task to run in svc-a and svc-b, got %v", paths)
+	}
+}

--- a/pk/plan.go
+++ b/pk/plan.go
@@ -3,6 +3,7 @@ package pk
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"slices"
 	"sort"
 
@@ -133,7 +134,7 @@ func newPlan(cfg *Config, gitRoot string, allDirs []string) (*Plan, error) {
 
 	collector := &taskCollector{
 		taskInstances: make([]taskInstance, 0),
-		seenTasks:     make(map[taskKey]bool),
+		seenTasks:     make(map[taskKey]int),
 		pathMappings:  make(map[string]pathInfo),
 		currentPath:   nil,
 		gitRoot:       gitRoot,
@@ -194,8 +195,8 @@ type taskInstance struct {
 
 // taskCollector is the internal state for walking the tree.
 type taskCollector struct {
-	taskInstances []taskInstance   // Tasks with their effective names.
-	seenTasks     map[taskKey]bool // Track seen (task, suffix) pairs for deduplication.
+	taskInstances []taskInstance  // Tasks with their effective names.
+	seenTasks     map[taskKey]int // Maps seen (task, suffix) pairs to their taskInstances index.
 	pathMappings  map[string]pathInfo
 	currentPath   *pathFilter // Current path context during tree walk.
 	gitRoot       string      // Git repository root.
@@ -357,20 +358,35 @@ func (pc *taskCollector) walk(r Runnable) error {
 			}
 		}
 
-		// Only collect unique (task, suffix) pairs for the flat tasks list.
-		key := taskKey{task: v, suffix: pc.activeNameSuffix}
-		if !pc.seenTasks[key] {
-			pc.seenTasks[key] = true
-			// Pre-merge flags for this task from all active scopes.
-			var mergedFlags map[string]any
-			for _, f := range pc.activeFlags {
-				if f.taskName == v.Name {
-					if mergedFlags == nil {
-						mergedFlags = make(map[string]any)
-					}
-					mergedFlags[f.flagName] = f.value
+		// Pre-merge flags for this task from all active scopes.
+		var mergedFlags map[string]any
+		for _, f := range pc.activeFlags {
+			if f.taskName == v.Name {
+				if mergedFlags == nil {
+					mergedFlags = make(map[string]any)
 				}
+				mergedFlags[f.flagName] = f.value
 			}
+		}
+
+		// Collect the task instance. A task may be referenced from multiple
+		// scopes (e.g., under different path filters); occurrences after the
+		// first merge their resolved paths into the existing instance so that
+		// auto execution and direct invocation agree on the union of paths.
+		key := taskKey{task: v, suffix: pc.activeNameSuffix}
+		if idx, seen := pc.seenTasks[key]; seen {
+			instance := &pc.taskInstances[idx]
+			if !reflect.DeepEqual(instance.flags, mergedFlags) {
+				return fmt.Errorf(
+					"task %q: conflicting flag overrides across scopes (%v vs %v); "+
+						"use WithNameSuffix to create distinct variants",
+					effectiveName, instance.flags, mergedFlags)
+			}
+			instance.resolvedPaths = unionPaths(instance.resolvedPaths, finalPaths)
+			instance.isManual = instance.isManual && pc.inManualSection
+			instance.verbose = instance.verbose || v.Verbose || pc.activeVerbose
+		} else {
+			pc.seenTasks[key] = len(pc.taskInstances)
 			pc.taskInstances = append(pc.taskInstances, taskInstance{
 				task:          v,
 				name:          effectiveName,
@@ -397,6 +413,11 @@ func (pc *taskCollector) walk(r Runnable) error {
 			allIncludes = []string{"."}
 		}
 
+		// Union with any mapping recorded by a previous occurrence of this task.
+		if existing, seen := pc.pathMappings[effectiveName]; seen {
+			allIncludes = unionPaths(existing.includePaths, allIncludes)
+			finalPaths = unionPaths(existing.resolvedPaths, finalPaths)
+		}
 		pc.pathMappings[effectiveName] = pathInfo{
 			includePaths:  allIncludes,
 			resolvedPaths: finalPaths,
@@ -475,6 +496,18 @@ func (pc *taskCollector) walk(r Runnable) error {
 	}
 
 	return nil
+}
+
+// unionPaths returns base with any paths from extra appended that are not
+// already present, preserving order. base is never mutated.
+func unionPaths(base, extra []string) []string {
+	result := slices.Clone(base)
+	for _, p := range extra {
+		if !slices.Contains(result, p) {
+			result = append(result, p)
+		}
+	}
+	return result
 }
 
 // excludeByPatterns filters out directories matching any of the patterns.

--- a/pk/plan_test.go
+++ b/pk/plan_test.go
@@ -1037,3 +1037,136 @@ func TestPlan_WithVerboseNotSetByDefault(t *testing.T) {
 		t.Error("expected verbose=false on task instance by default")
 	}
 }
+
+func TestNewPlan_TaskInMultipleScopes(t *testing.T) {
+	allDirs := []string{".", "svc-a", "svc-b"}
+
+	type multiScopeFlags struct {
+		Mode string `flag:"mode" usage:"mode flag"`
+	}
+
+	newTask := func() *Task {
+		return &Task{Name: "lint", Usage: "lint code", Do: func(_ context.Context) error { return nil }}
+	}
+
+	t.Run("UnionsPaths", func(t *testing.T) {
+		task := newTask()
+		cfg := &Config{
+			Auto: Serial(
+				WithOptions(task, WithPath("svc-a")),
+				WithOptions(task, WithPath("svc-b")),
+			),
+		}
+
+		plan, err := newPlan(cfg, "/tmp", allDirs)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wantPaths := []string{"svc-a", "svc-b"}
+		instance := plan.taskInstanceByName("lint")
+		if instance == nil {
+			t.Fatal("expected task instance 'lint' in plan")
+		}
+		if !slices.Equal(instance.resolvedPaths, wantPaths) {
+			t.Errorf("instance paths: expected %v, got %v", wantPaths, instance.resolvedPaths)
+		}
+		mapping, ok := plan.pathMappings["lint"]
+		if !ok {
+			t.Fatal("expected path mapping for 'lint'")
+		}
+		if !slices.Equal(mapping.resolvedPaths, wantPaths) {
+			t.Errorf("mapping resolved paths: expected %v, got %v", wantPaths, mapping.resolvedPaths)
+		}
+		if !slices.Equal(mapping.includePaths, wantPaths) {
+			t.Errorf("mapping include paths: expected %v, got %v", wantPaths, mapping.includePaths)
+		}
+	})
+
+	t.Run("IdenticalFlagOverridesAllowed", func(t *testing.T) {
+		task := newTask()
+		task.Flags = multiScopeFlags{Mode: "default"}
+		cfg := &Config{
+			Auto: Serial(
+				WithOptions(task, WithPath("svc-a"), WithFlags(multiScopeFlags{Mode: "fast"})),
+				WithOptions(task, WithPath("svc-b"), WithFlags(multiScopeFlags{Mode: "fast"})),
+			),
+		}
+
+		plan, err := newPlan(cfg, "/tmp", allDirs)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		instance := plan.taskInstanceByName("lint")
+		if instance == nil {
+			t.Fatal("expected task instance 'lint' in plan")
+		}
+		if instance.flags["mode"] != "fast" {
+			t.Errorf("expected mode=%q, got %v", "fast", instance.flags["mode"])
+		}
+		wantPaths := []string{"svc-a", "svc-b"}
+		if !slices.Equal(instance.resolvedPaths, wantPaths) {
+			t.Errorf("instance paths: expected %v, got %v", wantPaths, instance.resolvedPaths)
+		}
+	})
+
+	t.Run("ConflictingFlagOverridesError", func(t *testing.T) {
+		task := newTask()
+		task.Flags = multiScopeFlags{Mode: "default"}
+		cfg := &Config{
+			Auto: Serial(
+				WithOptions(task, WithPath("svc-a"), WithFlags(multiScopeFlags{Mode: "fast"})),
+				WithOptions(task, WithPath("svc-b"), WithFlags(multiScopeFlags{Mode: "slow"})),
+			),
+		}
+
+		_, err := newPlan(cfg, "/tmp", allDirs)
+		if err == nil {
+			t.Fatal("expected error for conflicting flag overrides across scopes")
+		}
+		if !strings.Contains(err.Error(), "conflicting flag overrides") {
+			t.Errorf("expected 'conflicting flag overrides' in error, got %q", err.Error())
+		}
+	})
+
+	t.Run("OverrideVsNoOverrideError", func(t *testing.T) {
+		task := newTask()
+		task.Flags = multiScopeFlags{Mode: "default"}
+		cfg := &Config{
+			Auto: Serial(
+				WithOptions(task, WithPath("svc-a"), WithFlags(multiScopeFlags{Mode: "fast"})),
+				WithOptions(task, WithPath("svc-b")),
+			),
+		}
+
+		_, err := newPlan(cfg, "/tmp", allDirs)
+		if err == nil {
+			t.Fatal("expected error when one scope overrides flags and another does not")
+		}
+		if !strings.Contains(err.Error(), "conflicting flag overrides") {
+			t.Errorf("expected 'conflicting flag overrides' in error, got %q", err.Error())
+		}
+	})
+
+	t.Run("AutoAndManualStaysAuto", func(t *testing.T) {
+		task := newTask()
+		cfg := &Config{
+			Auto:   WithOptions(task, WithPath("svc-a")),
+			Manual: []Runnable{task},
+		}
+
+		plan, err := newPlan(cfg, "/tmp", allDirs)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		instance := plan.taskInstanceByName("lint")
+		if instance == nil {
+			t.Fatal("expected task instance 'lint' in plan")
+		}
+		if instance.isManual {
+			t.Error("task referenced in both Auto and Manual should stay auto")
+		}
+	})
+}


### PR DESCRIPTION
## Why?

Referencing the same task under multiple path scopes silently broke execution:

```go
Auto: pk.Serial(
    pk.WithOptions(Lint, pk.WithPath("svc-a")),
    pk.WithOptions(Lint, pk.WithPath("svc-b")),
)
```

- `taskInstances` kept the **first** occurrence's paths ([plan.go:374](https://github.com/fredrikaverpil/pocket/blob/1bc047b298256331f4e5f237439c54c031ac7444/pk/plan.go#L374)), `pathMappings` kept the **last** ([plan.go:418](https://github.com/fredrikaverpil/pocket/blob/1bc047b298256331f4e5f237439c54c031ac7444/pk/plan.go#L418))
- The membership check in [task.go:143](https://github.com/fredrikaverpil/pocket/blob/1bc047b298256331f4e5f237439c54c031ac7444/pk/task.go#L143) then rejected the disagreeing paths
- Result: bare `./pok` ran the task only in svc-b; `./pok lint` ran it **nowhere** and reported success

## What?

- Merge repeat occurrences into the existing task instance: union of resolved paths, `isManual` AND, `verbose` OR
- Union `pathMappings` entries instead of overwriting, so auto execution, direct invocation, visibility, and shim generation all agree
- Fail plan building with a clear error when scopes set conflicting `WithFlags` overrides for the same task (one instance cannot carry two flag sets); `WithNameSuffix` remains the way to create distinct variants
- Add plan-level and e2e regression tests for both execution modes, flag conflicts, and Auto+Manual references

## Notes

- Per-path deduplication still prevents double runs in overlapping scopes
- A scope with `WithFlags` and a scope without now error too (previously the override silently won via first-wins); this is intentional per the explicit-over-silent decision
- `go-vulncheck` currently fails on `main` as well (stdlib vulns fixed in go1.26.4) — unrelated to this change