### PR TITLE
fix(pk): narrow nested path scopes to the enclosing scope's directory

### DIFF
--- a/.claude/skills/pocket-engine/INTERNALS.md
+++ b/.claude/skills/pocket-engine/INTERNALS.md
@@ -173,6 +173,14 @@ Wraps an inner runnable with path/option configuration:
    - Set path in context via `ContextWithPath`
    - Execute inner runnable
 
+When pathFilters nest, the inner filter does not re-iterate its own resolved
+paths. If the context already carries a path (set by an enclosing pathFilter),
+the inner filter narrows to that directory — executing once if the directory is
+in its resolved set, not at all otherwise. Nested scopes refine outer scopes
+(inner paths are always a subset of the outer's), so this yields each directory
+exactly once per pass instead of an N×M cross product, which would otherwise
+surface as duplicate runs under `WithForceRun`.
+
 ---
 
 ## Exec pipeline

--- a/pk/e2e_test.go
+++ b/pk/e2e_test.go
@@ -713,3 +713,85 @@ func TestE2E_AutoExec_GlobalTaskExcludedPathStillRunsElsewhere(t *testing.T) {
 	want := []execRecord{{TaskName: "global-install", Path: "svc-b"}}
 	assert.DeepEqual(t, rec.records, want)
 }
+
+func TestE2E_AutoExec_NestedScopesWithForceRun(t *testing.T) {
+	tmpDir := e2eSetup(t)
+	for _, d := range []string{"svc-a", "svc-b"} {
+		if err := os.MkdirAll(filepath.Join(tmpDir, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	rec := newRecorder()
+	task := rec.task("nested")
+
+	cfg := &Config{
+		Auto: WithOptions(
+			WithOptions(task, WithPath("svc-.*"), WithForceRun()),
+			WithPath("svc-.*"),
+		),
+	}
+	plan, err := newPublicPlan(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := e2eCtx(t, plan)
+	ctx = context.WithValue(ctx, ctxkey.AutoExec{}, true)
+	if err := cfg.Auto.run(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// The inner scope must narrow to the outer scope's current directory
+	// instead of re-iterating all of its paths; without that, WithForceRun
+	// exposes the multiplication by running the task 2x2 = 4 times.
+	want := []execRecord{
+		{TaskName: "nested", Path: "svc-a"},
+		{TaskName: "nested", Path: "svc-b"},
+	}
+	assert.DeepEqual(t, rec.records, want)
+}
+
+func TestE2E_AutoExec_NestedScopeFollowsOuterIteration(t *testing.T) {
+	tmpDir := e2eSetup(t)
+	for _, d := range []string{"svc-a", "svc-b"} {
+		if err := os.MkdirAll(filepath.Join(tmpDir, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	rec := newRecorder()
+	wide := rec.task("wide")
+	narrow := rec.task("narrow")
+
+	cfg := &Config{
+		Auto: WithOptions(
+			Serial(
+				wide,
+				WithOptions(narrow, WithPath("svc-.*")),
+			),
+			WithPath("svc-.*"),
+		),
+	}
+	plan, err := newPublicPlan(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := e2eCtx(t, plan)
+	ctx = context.WithValue(ctx, ctxkey.AutoExec{}, true)
+	if err := cfg.Auto.run(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Each pass of the outer scope runs the inner scope only at the outer's
+	// current directory: narrow must not visit svc-b while the outer scope is
+	// still iterating svc-a.
+	want := []execRecord{
+		{TaskName: "wide", Path: "svc-a"},
+		{TaskName: "narrow", Path: "svc-a"},
+		{TaskName: "wide", Path: "svc-b"},
+		{TaskName: "narrow", Path: "svc-b"},
+	}
+	assert.DeepEqual(t, rec.records, want)
+}

--- a/pk/options.go
+++ b/pk/options.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 
 	"github.com/fredrikaverpil/pocket/pk/internal/ctxkey"
 	pkrun "github.com/fredrikaverpil/pocket/pk/run"
@@ -237,13 +238,23 @@ func (pf *pathFilter) run(ctx context.Context) error {
 	}
 
 	paths := pf.resolvedPaths
+
+	// An enclosing pathFilter has already selected a directory for this pass.
+	// Nested scopes refine outer scopes, so narrow to that directory instead of
+	// re-iterating all resolved paths, which would multiply executions of the
+	// inner runnable (visible with WithForceRun, wasteful otherwise).
+	if outerPath, ok := ctx.Value(ctxkey.Path{}).(string); ok {
+		if !slices.Contains(paths, outerPath) {
+			return nil
+		}
+		paths = []string{outerPath}
+	}
+
 	if taskScope := taskScopeFromEnv(); isAutoExec(ctx) && taskScope != "" {
-		paths = nil
-		for _, path := range pf.resolvedPaths {
-			if path == taskScope {
-				paths = []string{path}
-				break
-			}
+		if slices.Contains(paths, taskScope) {
+			paths = []string{taskScope}
+		} else {
+			paths = nil
 		}
 	}
 


### PR DESCRIPTION
## Why?

- Nested `pathFilter`s each re-iterated their own resolved paths, so an inner scope under an outer scope executed its inner runnable as an N×M cross product.
- Per-path deduplication masked this, but `WithForceRun` disables dedup: a task under two nested scopes resolving to 2 directories ran 4 times instead of 2.
- Even with dedup intact, inner tasks visited later directories while the outer scope was still iterating an earlier one (wasted traversal, surprising ordering).
- Third engine bug from the core engine review, following #103 and #105.

## What?

- `pathFilter.run` now narrows to the directory already selected by an enclosing filter: it executes once if that directory is in its resolved set, not at all otherwise ([pk/options.go:239](https://github.com/fredrikaverpil/pocket/blob/ac4e7434a07517398cf2e7b78843913dc1cf06f4/pk/options.go#L239)).
- This is sound because nested scopes refine outer scopes: an inner filter's resolved paths are always a subset of the outer's.
- Restructure the `TASK_SCOPE` narrowing to compose with the new check.
- Add e2e regression tests for the `WithForceRun` multiplication and for per-directory ordering; document the narrowing in the engine internals doc.

## Notes

- Unresolved filters (e.g. `WithOptions` inside a `Task.Body`, which plan building never walks) keep their previous never-run behavior: narrowing against an empty set yields nothing, same as iterating zero paths before.