### PR TITLE
fix(pk): store pathFilter resolution off shared composition nodes

### DIFF
--- a/pk/e2e_test.go
+++ b/pk/e2e_test.go
@@ -795,3 +795,98 @@ func TestE2E_AutoExec_NestedScopeFollowsOuterIteration(t *testing.T) {
 	}
 	assert.DeepEqual(t, rec.records, want)
 }
+
+func TestE2E_AutoExec_ReusedScopeKeepsAllPaths(t *testing.T) {
+	tmpDir := e2eSetup(t)
+	for _, d := range []string{"svc-a", "svc-b"} {
+		if err := os.MkdirAll(filepath.Join(tmpDir, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	rec := newRecorder()
+	task := rec.task("reused")
+
+	// The same WithOptions value appears twice: first standalone (resolving to
+	// svc-a and svc-b), then narrowed to svc-a by an enclosing scope.
+	shared := WithOptions(task, WithPath("svc-.*"))
+	cfg := &Config{
+		Auto: Serial(
+			shared,
+			WithOptions(shared, WithPath("svc-a")),
+		),
+	}
+	plan, err := newPublicPlan(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := e2eCtx(t, plan)
+	ctx = context.WithValue(ctx, ctxkey.AutoExec{}, true)
+	if err := cfg.Auto.run(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Plan building must not let the narrowed occurrence overwrite the shared
+	// node's paths; the standalone occurrence still runs in both directories
+	// (the narrowed second occurrence is then deduplicated at svc-a).
+	want := []execRecord{
+		{TaskName: "reused", Path: "svc-a"},
+		{TaskName: "reused", Path: "svc-b"},
+	}
+	assert.DeepEqual(t, rec.records, want)
+}
+
+func TestE2E_AutoExec_ReusedDetectScopeKeepsAllPaths(t *testing.T) {
+	tmpDir := e2eSetup(t)
+	for _, d := range []string{"svc-a", "svc-b"} {
+		if err := os.MkdirAll(filepath.Join(tmpDir, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(
+			filepath.Join(tmpDir, d, "go.mod"),
+			[]byte("module "+d),
+			0o644,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	rec := newRecorder()
+	task := rec.task("detected")
+
+	// A detect-based scope reused at two tree positions: first standalone
+	// (detecting svc-a and svc-b), then narrowed to svc-a by an enclosing scope.
+	// Detect filters record includePaths from the resolution of the enclosing
+	// pathFilter, so this also exercises that the per-occurrence resolution is
+	// not clobbered when the node is shared.
+	shared := WithOptions(task, WithDetect(DetectByFile("go.mod")))
+	cfg := &Config{
+		Auto: Serial(
+			shared,
+			WithOptions(shared, WithPath("svc-a")),
+		),
+	}
+	plan, err := newPublicPlan(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The shared detect node keeps both detected directories as includePaths
+	// (unioned across occurrences), not just the last occurrence's narrowing.
+	assert.DeepEqual(t, plan.pathMappings["detected"].includePaths, []string{"svc-a", "svc-b"})
+
+	ctx := e2eCtx(t, plan)
+	ctx = context.WithValue(ctx, ctxkey.AutoExec{}, true)
+	if err := cfg.Auto.run(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// The standalone occurrence runs in both detected directories; the narrowed
+	// second occurrence is deduplicated at svc-a.
+	want := []execRecord{
+		{TaskName: "detected", Path: "svc-a"},
+		{TaskName: "detected", Path: "svc-b"},
+	}
+	assert.DeepEqual(t, rec.records, want)
+}

--- a/pk/options.go
+++ b/pk/options.go
@@ -191,17 +191,20 @@ func DetectByFile(filenames ...string) DetectFunc {
 // It determines which directories to execute in based on include/exclude patterns
 // and optional detection functions.
 type pathFilter struct {
-	inner          Runnable
-	includePaths   []string
-	excludePaths   []excludePattern
-	skippedTasks   []string
-	flags          []flagOverride
-	nameSuffix     string     // Suffix to append to task names (e.g., ":3.9").
-	detectFunc     DetectFunc // Optional detection function for dynamic path discovery.
-	resolvedPaths  []string   // Cached resolved paths from plan building.
-	forceRun       bool       // Disable task deduplication for the wrapped Runnable.
-	verbose        bool       // Force verbose mode for the wrapped Runnable.
-	noticePatterns []string   // Custom notice detection patterns (nil = use default).
+	inner        Runnable
+	includePaths []string
+	excludePaths []excludePattern
+	skippedTasks []string
+	flags        []flagOverride
+	nameSuffix   string     // Suffix to append to task names (e.g., ":3.9").
+	detectFunc   DetectFunc // Optional detection function for dynamic path discovery.
+	// resolvedPaths holds resolved paths for engine-constructed filters (e.g.
+	// JSON commands). Walked filters use Plan.pfResolved instead.
+	resolvedPaths []string
+
+	forceRun       bool     // Disable task deduplication for the wrapped Runnable.
+	verbose        bool     // Force verbose mode for the wrapped Runnable.
+	noticePatterns []string // Custom notice detection patterns (nil = use default).
 }
 
 type excludePattern struct {
@@ -219,7 +222,8 @@ type flagOverride struct {
 
 // run implements the Runnable interface.
 // It executes the inner Runnable for each resolved path.
-// Paths are resolved during plan building and cached in resolvedPaths.
+// Paths are resolved during plan building and recorded in Plan.pfResolved
+// (engine-constructed filters fall back to the resolvedPaths field).
 // Flag overrides are pre-computed during planning and read from Plan.taskInstanceByName().
 func (pf *pathFilter) run(ctx context.Context) error {
 	// If forceRun is set, propagate it to the context.
@@ -237,7 +241,15 @@ func (pf *pathFilter) run(ctx context.Context) error {
 		ctx = context.WithValue(ctx, ctxkey.NoticePatterns{}, pf.noticePatterns)
 	}
 
+	// Walked filters read their resolved paths from the Plan (keyed by this
+	// pathFilter), so plan building never mutates the shared composition node.
+	// Engine-constructed filters (e.g. JSON commands) carry their own field.
 	paths := pf.resolvedPaths
+	if p := planFromContext(ctx); p != nil {
+		if walked, ok := p.pfResolved[pf]; ok {
+			paths = walked
+		}
+	}
 
 	// An enclosing pathFilter has already selected a directory for this pass.
 	// Nested scopes refine outer scopes, so narrow to that directory instead of

--- a/pk/plan.go
+++ b/pk/plan.go
@@ -54,6 +54,14 @@ type Plan struct {
 
 	// shimConfig holds the shim generation configuration from Config.
 	shimConfig *ShimConfig
+
+	// pfResolved maps each pathFilter in the composition tree to the directories
+	// it executes in. Resolution results are stored here rather than on the
+	// pathFilter itself so that plan building never mutates the user's shared
+	// composition nodes: the same WithOptions value referenced from multiple tree
+	// positions accumulates (unions) its paths here instead of overwriting a
+	// field. Read at execution time by pathFilter.run via the Plan in context.
+	pfResolved map[*pathFilter][]string
 }
 
 // ShimConfig returns the resolved shim configuration from the [Config].
@@ -136,6 +144,7 @@ func newPlan(cfg *Config, gitRoot string, allDirs []string) (*Plan, error) {
 		taskInstances: make([]taskInstance, 0),
 		seenTasks:     make(map[taskKey]int),
 		pathMappings:  make(map[string]pathInfo),
+		pfResolved:    make(map[*pathFilter][]string),
 		currentPath:   nil,
 		gitRoot:       gitRoot,
 		allDirs:       allDirs,
@@ -177,6 +186,7 @@ func newPlan(cfg *Config, gitRoot string, allDirs []string) (*Plan, error) {
 		pathMappings:      collector.pathMappings,
 		moduleDirectories: moduleDirectories,
 		shimConfig:        shimConfig,
+		pfResolved:        collector.pfResolved,
 	}, nil
 }
 
@@ -195,15 +205,17 @@ type taskInstance struct {
 
 // taskCollector is the internal state for walking the tree.
 type taskCollector struct {
-	taskInstances []taskInstance  // Tasks with their effective names.
-	seenTasks     map[taskKey]int // Maps seen (task, suffix) pairs to their taskInstances index.
-	pathMappings  map[string]pathInfo
-	currentPath   *pathFilter // Current path context during tree walk.
-	gitRoot       string      // Git repository root.
-	allDirs       []string    // Cached directory list from filesystem walk.
+	taskInstances []taskInstance           // Tasks with their effective names.
+	seenTasks     map[taskKey]int          // Maps seen (task, suffix) pairs to their taskInstances index.
+	pathMappings  map[string]pathInfo      // Per-task execution paths by effective name.
+	pfResolved    map[*pathFilter][]string // Resolved paths per pathFilter (unioned across occurrences).
+	currentPath   *pathFilter              // Current path context during tree walk.
+	gitRoot       string                   // Git repository root.
+	allDirs       []string                 // Cached directory list from filesystem walk.
 
 	// Cumulative state
 	candidates       []string         // Current allowed directories.
+	currentResolved  []string         // Resolved paths of the innermost enclosing pathFilter.
 	activeExcludes   []excludePattern // All excludes in current scope.
 	activeSkips      []string         // All skipped tasks in current scope.
 	activeNameSuffix string           // Current name suffix from WithNameSuffix.
@@ -404,7 +416,7 @@ func (pc *taskCollector) walk(r Runnable) error {
 		var allIncludes []string
 		if pc.currentPath != nil {
 			if pc.currentPath.detectFunc != nil && len(pc.currentPath.includePaths) == 0 {
-				allIncludes = pc.currentPath.resolvedPaths
+				allIncludes = pc.currentResolved
 			} else {
 				allIncludes = pc.currentPath.includePaths
 			}
@@ -439,14 +451,21 @@ func (pc *taskCollector) walk(r Runnable) error {
 
 	case *pathFilter:
 		// 1. Resolve paths for this filter based on current candidates.
+		// Store the result in the Plan (keyed by this pathFilter) rather than on
+		// the node itself: the same WithOptions value may appear at multiple tree
+		// positions, so occurrences union their paths here instead of the last
+		// walk overwriting a shared field. The union is a correct superset at
+		// execution time — pathFilter.run iterates it at the top level and narrows
+		// to a single enclosing directory when nested.
 		resolved, err := pc.filterPaths(v)
 		if err != nil {
 			return err
 		}
-		v.resolvedPaths = resolved
+		pc.pfResolved[v] = unionPaths(pc.pfResolved[v], resolved)
 
 		// 2. Save state for nesting.
 		prevCandidates := pc.candidates
+		prevResolved := pc.currentResolved
 		prevExcludes := pc.activeExcludes
 		prevSkips := pc.activeSkips
 		prevPath := pc.currentPath
@@ -461,7 +480,8 @@ func (pc *taskCollector) walk(r Runnable) error {
 		}
 
 		// 3. Update state with new constraints.
-		pc.candidates = v.resolvedPaths
+		pc.candidates = resolved
+		pc.currentResolved = resolved
 		pc.activeExcludes = append(pc.activeExcludes, v.excludePaths...)
 		pc.activeSkips = append(pc.activeSkips, v.skippedTasks...)
 		pc.activeFlags = append(pc.activeFlags, resolvedFlags...)
@@ -484,6 +504,7 @@ func (pc *taskCollector) walk(r Runnable) error {
 
 		// 5. Restore state.
 		pc.candidates = prevCandidates
+		pc.currentResolved = prevResolved
 		pc.activeExcludes = prevExcludes
 		pc.activeSkips = prevSkips
 		pc.currentPath = prevPath


### PR DESCRIPTION
## Why

Plan building mutated user-owned composition nodes: `walk` wrote resolved paths onto the user's `pathFilter` (`v.resolvedPaths = resolved`). When the same `WithOptions(...)` value was referenced from multiple tree positions, the second walk overwrote the first's resolution, and both runtime references then used last-wins paths. This is finding #4 in `REVIEW.md` (same root cause as the already-fixed #1, #3).

```go
// One scope value, referenced in two tree positions.
lintAll := pk.WithOptions(Lint, pk.WithPath("svc-.*")) // resolves to svc-a, svc-b

Auto: pk.Serial(
    lintAll,                                       // expect: lint in svc-a AND svc-b
    pk.WithOptions(lintAll, pk.WithPath("svc-a")), // also lint in svc-a
)
// Before: the second occurrence overwrote lintAll's resolved paths,
// so the standalone occurrence silently dropped svc-b.
```

## What

- Move per-`pathFilter` resolution into a `Plan.pfResolved` side-table (`map[*pathFilter][]string`), keyed by the pathFilter pointer and **unioned** across occurrences, so plan building no longer writes to the shared composition node.
- `pathFilter.run` reads the side-table from the `Plan` in context, falling back to the `resolvedPaths` field for engine-constructed filters (JSON commands), which are never aliased.
- Detect-based scopes record `includePaths` from the innermost enclosing pathFilter's resolution, now carried in `taskCollector.currentResolved` instead of the removed node field.

The union is a correct superset given the #106 narrowing: a top-level occurrence iterates the union, while a nested occurrence narrows to its enclosing directory via context membership. The union only ever contains paths that pass the filter's own pattern, so the runtime membership gate can never run a task at an excluded path.

## Notes

- Regression tests added:
  - `TestE2E_AutoExec_ReusedScopeKeepsAllPaths` — a non-last `WithPath` occurrence reused as the top-level iteration source previously dropped `svc-b` (overwrite); now keeps both.
  - `TestE2E_AutoExec_ReusedDetectScopeKeepsAllPaths` — covers the `currentResolved` substitution for detect scopes by asserting recorded `includePaths` plus runtime execution.
- `go test ./pk/...`, `go vet`, and `-race` on the e2e suite are green; `go-lint` passes.