### PR TITLE
fix(pk): reject pathFilter inside Task.Body at plan time

### DIFF
--- a/pk/plan.go
+++ b/pk/plan.go
@@ -307,6 +307,11 @@ func (pc *taskCollector) walk(r Runnable) error {
 		if v.Do != nil && v.Body != nil {
 			return fmt.Errorf("task %q: Do and Body are mutually exclusive", v.Name)
 		}
+		if v.Body != nil {
+			if err := validateBodyComposition(v.Name, v.Body); err != nil {
+				return err
+			}
+		}
 		// Build internal flagSet if not already built.
 		if v.flagSet == nil {
 			if err := v.buildFlagSet(); err != nil {
@@ -516,6 +521,40 @@ func (pc *taskCollector) walk(r Runnable) error {
 		panic(fmt.Sprintf("pk: unknown Runnable type %T in walk", r))
 	}
 
+	return nil
+}
+
+// validateBodyComposition rejects pathFilters anywhere inside a Task.Body. A
+// pathFilter (pk.WithPath/WithDetect/WithOptions) depends on plan-time path
+// resolution that only happens for the top-level composition tree; inside a Body
+// it stays unresolved and silently iterates zero paths at runtime. The check
+// recurses through Serial/Parallel and into nested Task bodies, which are equally
+// subject to the rule. Do and command runnables are valid leaves.
+func validateBodyComposition(taskName string, r Runnable) error {
+	switch v := r.(type) {
+	case *pathFilter:
+		return fmt.Errorf("task %q: pk.WithPath/WithDetect/WithOptions is not allowed "+
+			"inside Task.Body; apply path scopes at the composition level instead "+
+			"(Body may contain Do, Task, Serial, Parallel)", taskName)
+	case *serial:
+		for _, child := range v.runnables {
+			if err := validateBodyComposition(taskName, child); err != nil {
+				return err
+			}
+		}
+	case *parallel:
+		for _, child := range v.runnables {
+			if err := validateBodyComposition(taskName, child); err != nil {
+				return err
+			}
+		}
+	case *Task:
+		// A nested task's own Body is equally subject to the rule; report it under
+		// its own name.
+		if v.Body != nil {
+			return validateBodyComposition(v.Name, v.Body)
+		}
+	}
 	return nil
 }
 

--- a/pk/plan_test.go
+++ b/pk/plan_test.go
@@ -2,6 +2,7 @@ package pk
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"strings"
 	"testing"
@@ -573,6 +574,77 @@ func TestNewPlan_DuplicateTaskName(t *testing.T) {
 		_, err := newPlan(cfg, "/tmp", allDirs)
 		if err != nil {
 			t.Errorf("unexpected error for different suffixes: %v", err)
+		}
+	})
+}
+
+func TestNewPlan_PathFilterInBodyRejected(t *testing.T) {
+	allDirs := []string{".", "svc-a", "svc-b"}
+	leaf := &Task{Name: "leaf", Usage: "leaf", Do: func(_ context.Context) error { return nil }}
+
+	// A pathFilter inside a Body never gets resolved by the plan walk and would
+	// silently iterate zero paths at runtime, so plan building must reject it.
+	t.Run("Rejected", func(t *testing.T) {
+		tests := []struct {
+			name string
+			body Runnable
+			// wantTask is the task name the error should blame. A pathFilter in a
+			// nested task's body is reported under that nested task, not the outer.
+			wantTask string
+		}{
+			{
+				name:     "Direct",
+				body:     WithOptions(leaf, WithPath("svc-a")),
+				wantTask: "outer",
+			},
+			{
+				name:     "InsideSerial",
+				body:     Serial(leaf, WithOptions(leaf, WithPath("svc-a"))),
+				wantTask: "outer",
+			},
+			{
+				name: "InsideParallel",
+				body: Parallel(
+					WithOptions(leaf, WithDetect(func(dirs []string, _ string) []string { return dirs })),
+				),
+				wantTask: "outer",
+			},
+			{
+				name: "InsideNestedTaskBody",
+				body: Serial(&Task{
+					Name: "inner",
+					Body: WithOptions(leaf, WithPath("svc-a")),
+				}),
+				wantTask: "inner",
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				cfg := &Config{Auto: &Task{Name: "outer", Usage: "outer", Body: tt.body}}
+				_, err := newPlan(cfg, "/tmp", allDirs)
+				if err == nil {
+					t.Fatal("expected error for pathFilter inside Task.Body, got nil")
+				}
+				if !strings.Contains(err.Error(), "not allowed inside Task.Body") {
+					t.Errorf("expected 'not allowed inside Task.Body' error, got: %v", err)
+				}
+				if want := fmt.Sprintf("task %q", tt.wantTask); !strings.Contains(err.Error(), want) {
+					t.Errorf("expected error to blame %s, got: %v", want, err)
+				}
+			})
+		}
+	})
+
+	// A Body composed only of Do/Task/Serial/Parallel is valid.
+	t.Run("Allowed", func(t *testing.T) {
+		cfg := &Config{Auto: &Task{
+			Name:  "outer",
+			Usage: "outer",
+			Body:  Serial(leaf, Do(func(_ context.Context) error { return nil })),
+		}}
+		_, err := newPlan(cfg, "/tmp", allDirs)
+		if err != nil {
+			t.Errorf("unexpected error for pathFilter-free Body: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## Why?

A `pathFilter` (`pk.WithPath`/`WithDetect`/`WithOptions`) placed inside a
`Task.Body` silently never runs. The plan walk never descends into `Body`, so
the filter is never resolved; at runtime it iterates zero paths and the wrapped
runnable is skipped — no error, exit 0.

```go
Task{
    Name: "deploy",
    Body: pk.WithOptions(deployOne, pk.WithPath("services/*")), // never runs
}
```

A composed `Body` looks like the top-level composition API, but only
`Do`/`Task`/`Serial`/`Parallel` actually work there. Found while self-reviewing
the fix for the nested-scope finding (#106).

## What?

- Validate `Body` subtrees during plan building (`case *Task`) and fail with a
  clear error if a `pathFilter` is found:
  `task "deploy": pk.WithPath/WithDetect/WithOptions is not allowed inside
  Task.Body; apply path scopes at the composition level instead`
- The check recurses through `Serial`/`Parallel` and into nested `Task` bodies,
  blaming the nested task by name. `Do` and command runnables stay valid leaves.
- Chose rejection over support: path scoping belongs at the composition level,
  and no existing task nests a pathFilter in a `Body` (every `Body:` is
  `Serial(Install, cmd())`), so nothing breaks.

## Notes

- Regression test `TestNewPlan_PathFilterInBodyRejected` covers
  direct/Serial/Parallel/nested-body rejection (incl. the blamed task name) plus
  a pathFilter-free `Body` that stays valid.
- `./pok go-lint` and `go-test` green.