### PR TITLE
fix(pk): scope CLI flag overrides to the invoked task

### DIFF
--- a/pk/cli.go
+++ b/pk/cli.go
@@ -132,7 +132,7 @@ func run(cfg *Config) (*executionTracker, error) {
 				}
 			})
 			if len(cliFlags) > 0 {
-				ctx = context.WithValue(ctx, ctxkey.CLIFlags{}, cliFlags)
+				ctx = withCLIFlags(ctx, taskName, cliFlags)
 			}
 		}
 

--- a/pk/context_internal.go
+++ b/pk/context_internal.go
@@ -47,11 +47,27 @@ func commitsCheckEnabled(ctx context.Context) bool {
 	return v
 }
 
-func cliFlagsFromContext(ctx context.Context) map[string]any {
-	if flags, ok := ctx.Value(ctxkey.CLIFlags{}).(map[string]any); ok {
-		return flags
+// cliFlagOverrides carries CLI-provided flag overrides together with the name
+// of the task they were aimed at. Scoping by target prevents the overrides from
+// leaking into subtasks composed within the invoked task's body that happen to
+// declare same-named flags.
+type cliFlagOverrides struct {
+	target string
+	flags  map[string]any
+}
+
+func withCLIFlags(ctx context.Context, target string, flags map[string]any) context.Context {
+	return context.WithValue(ctx, ctxkey.CLIFlags{}, cliFlagOverrides{target: target, flags: flags})
+}
+
+// cliFlagsForTask returns the CLI flag overrides only if they were aimed at
+// effectiveName, otherwise nil.
+func cliFlagsForTask(ctx context.Context, effectiveName string) map[string]any {
+	o, ok := ctx.Value(ctxkey.CLIFlags{}).(cliFlagOverrides)
+	if !ok || o.target != effectiveName {
+		return nil
 	}
-	return nil
+	return o.flags
 }
 
 func taskScopeFromEnv() string {

--- a/pk/e2e_test.go
+++ b/pk/e2e_test.go
@@ -232,7 +232,7 @@ func TestE2E_ExecuteTask_CLIFlags(t *testing.T) {
 
 	ctx := e2eCtx(t, plan)
 	// CLI flags have highest priority.
-	ctx = context.WithValue(ctx, ctxkey.CLIFlags{}, map[string]any{"mode": "cli-value"})
+	ctx = withCLIFlags(ctx, "cli-flagged", map[string]any{"mode": "cli-value"})
 
 	if err := ExecuteTask(ctx, "cli-flagged", plan); err != nil {
 		t.Fatal(err)
@@ -243,6 +243,52 @@ func TestE2E_ExecuteTask_CLIFlags(t *testing.T) {
 	}
 	if rec.records[0].Flags["mode"] != "cli-value" {
 		t.Errorf("expected mode=%q, got %q", "cli-value", rec.records[0].Flags["mode"])
+	}
+}
+
+// TestE2E_ExecuteTask_CLIFlagsScopedToTarget verifies that CLI flag overrides
+// apply only to the task named on the command line, not to subtasks composed in
+// its body that declare same-named flags (REVIEW.md finding 6).
+func TestE2E_ExecuteTask_CLIFlagsScopedToTarget(t *testing.T) {
+	tests := []struct {
+		name     string
+		target   string         // task the CLI flags were aimed at
+		wantFlag map[string]any // flags the child subtask should observe
+	}{
+		{
+			name:     "aimed at parent does not leak to child",
+			target:   "parent",
+			wantFlag: map[string]any{"mode": "child-default"},
+		},
+		{
+			name:     "aimed at child still routes to child",
+			target:   "child",
+			wantFlag: map[string]any{"mode": "cli-value"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e2eSetup(t)
+			rec := newRecorder()
+			child := rec.taskWithFlags("child", cliFlaggedFlags{Mode: "child-default"})
+			parent := &Task{
+				Name:  "parent",
+				Usage: "parent",
+				Flags: cliFlaggedFlags{Mode: "parent-default"},
+				Body:  child,
+			}
+
+			plan, err := newPublicPlan(&Config{Auto: parent})
+			assert.NilError(t, err)
+
+			ctx := e2eCtx(t, plan)
+			ctx = withCLIFlags(ctx, tt.target, map[string]any{"mode": "cli-value"})
+
+			assert.NilError(t, ExecuteTask(ctx, "parent", plan))
+
+			assert.Equal(t, len(rec.records), 1)
+			assert.DeepEqual(t, rec.records[0].Flags, tt.wantFlag)
+		})
 	}
 }
 

--- a/pk/task.go
+++ b/pk/task.go
@@ -116,7 +116,7 @@ func (t *Task) run(ctx context.Context) error {
 		if instance != nil {
 			maps.Copy(resolved, instance.flags)
 		}
-		if cliFlags := cliFlagsFromContext(ctx); cliFlags != nil {
+		if cliFlags := cliFlagsForTask(ctx, effectiveName); cliFlags != nil {
 			maps.Copy(resolved, cliFlags)
 		}
 		ctx = context.WithValue(ctx, ctxkey.TaskFlags{}, resolved)


### PR DESCRIPTION
## Why?

- `./pok mytask -foo x` stored the CLI flag overrides in context as a bare map, applied by **every** task in the invoked subtree that declared a flag named `foo`.
- A composed child task that happens to declare a same-named flag silently inherited the override it was never meant to receive.

```go
parent := &Task{
    Name:  "parent",
    Flags: cliFlaggedFlags{Mode: "parent-default"},
    Body:  child, // child also declares -mode
}
// ./pok parent -mode x  ->  child wrongly saw mode="x"
```

## What?

- Carry overrides in a `cliFlagOverrides{target, flags}` struct keyed to the invoked task's effective name ([context_internal.go](https://github.com/fredrikaverpil/pocket/blob/03f8256bc42b88b1ee3d95c9657486fdae5885f5/pk/context_internal.go#L50)).
- Store the typed task name as the target when entering ([cli.go:135](https://github.com/fredrikaverpil/pocket/blob/03f8256bc42b88b1ee3d95c9657486fdae5885f5/pk/cli.go#L135)).
- Apply overrides only when `effectiveName == target` ([task.go:119](https://github.com/fredrikaverpil/pocket/blob/03f8256bc42b88b1ee3d95c9657486fdae5885f5/pk/task.go#L119)). Body subtasks compute their own names and no longer inherit; the directly-invoked task still gets its flags because its effective name equals the typed name.
- Add `TestE2E_ExecuteTask_CLIFlagsScopedToTarget` covering non-leak (aimed at parent) and correct routing (aimed at child); update the existing CLI-flags test to the new carrier.

## Notes

- Flags still live in context under the same `ctxkey.CLIFlags{}` key and propagate down the subtree; the read side gates on the target. This is deliberate — the invoked task can re-enter `task.run` once per resolved path, so the override must remain in context for each.
- `ctxkey.CLIFlags` is under `pk/internal/`, so the carrier-type change is not a public API break.
