### PR TITLE
fix(pk): error on non-convertible flag values in mapToStruct

### DIFF
--- a/pk/run/flags.go
+++ b/pk/run/flags.go
@@ -27,6 +27,10 @@ func GetFlags[T any](ctx context.Context) T {
 }
 
 // mapToStruct populates a flags struct pointer from a map[string]any.
+// A field is left untouched when its flag key is absent from the map; pointer
+// fields therefore stay nil ("not set"). A present value that is not convertible
+// to the field's type returns an error rather than silently dropping the value
+// or setting a zero-value pointer.
 func mapToStruct(m map[string]any, dst any) error {
 	v := reflect.ValueOf(dst)
 	if v.Kind() != reflect.Pointer || v.Elem().Kind() != reflect.Struct {
@@ -50,14 +54,23 @@ func mapToStruct(m map[string]any, dst any) error {
 		}
 		field := v.Field(i)
 		rv := reflect.ValueOf(val)
-		if field.Kind() == reflect.Pointer {
-			ptr := reflect.New(field.Type().Elem())
-			if rv.Type().ConvertibleTo(field.Type().Elem()) {
-				ptr.Elem().Set(rv.Convert(field.Type().Elem()))
-			}
+
+		// The conversion target is the element type for pointer fields.
+		isPtr := field.Kind() == reflect.Pointer
+		target := field.Type()
+		if isPtr {
+			target = target.Elem()
+		}
+		if !rv.Type().ConvertibleTo(target) {
+			return fmt.Errorf("flag %q: cannot convert %T to %s", key, val, target)
+		}
+		converted := rv.Convert(target)
+		if isPtr {
+			ptr := reflect.New(target)
+			ptr.Elem().Set(converted)
 			field.Set(ptr)
-		} else if rv.Type().ConvertibleTo(field.Type()) {
-			field.Set(rv.Convert(field.Type()))
+		} else {
+			field.Set(converted)
 		}
 	}
 	return nil

--- a/pk/run/flags_test.go
+++ b/pk/run/flags_test.go
@@ -1,0 +1,75 @@
+package run
+
+import (
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+type mapToStructFlags struct {
+	Name    string        `flag:"name"`
+	Count   int           `flag:"count"`
+	Enabled bool          `flag:"enabled"`
+	Timeout time.Duration `flag:"timeout"`
+	OptBool *bool         `flag:"opt-bool"`
+	OptStr  *string       `flag:"opt-str"`
+}
+
+func TestMapToStruct(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   map[string]any
+		want    mapToStructFlags
+		wantErr string // substring of the expected error; empty means no error
+	}{
+		{
+			name:  "non-pointer convertible values are set",
+			input: map[string]any{"name": "x", "count": 3, "enabled": true},
+			want:  mapToStructFlags{Name: "x", Count: 3, Enabled: true},
+		},
+		{
+			name:  "pointer convertible values yield non-nil pointers",
+			input: map[string]any{"opt-bool": true, "opt-str": "y"},
+			want:  mapToStructFlags{OptBool: new(true), OptStr: new("y")},
+		},
+		{
+			name:  "absent pointer keys stay nil",
+			input: map[string]any{"name": "x"},
+			want:  mapToStructFlags{Name: "x"},
+		},
+		{
+			name:  "duration converts from int64",
+			input: map[string]any{"timeout": int64(5 * time.Second)},
+			want:  mapToStructFlags{Timeout: 5 * time.Second},
+		},
+		{
+			name:    "non-pointer non-convertible value errors",
+			input:   map[string]any{"enabled": 5}, // int is not convertible to bool
+			wantErr: `flag "enabled": cannot convert int to bool`,
+		},
+		{
+			name:    "pointer non-convertible value errors",
+			input:   map[string]any{"opt-bool": "nope"}, // string is not convertible to bool
+			wantErr: `flag "opt-bool": cannot convert string to bool`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got mapToStructFlags
+			err := mapToStruct(tt.input, &got)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			assert.NilError(t, err)
+			assert.DeepEqual(t, got, tt.want)
+		})
+	}
+}
+
+func TestMapToStruct_RejectsNonStructDst(t *testing.T) {
+	var notStruct int
+	err := mapToStruct(map[string]any{}, &notStruct)
+	assert.ErrorContains(t, err, "pointer to struct")
+}


### PR DESCRIPTION
## Why?

- `mapToStruct` silently mishandled a map value whose type was not convertible to the destination field:
  - **pointer field** → set to a non-nil zero-value pointer, turning "not set" (nil) into "explicitly zero" **and** dropping the value;
  - **non-pointer field** → left at its zero value with no signal at all.
- This only happens on a genuine type mismatch (a `GetFlags[T]` whose `T` declares a different Go type for a flag name than the registered one, or a hand-built map), so it should fail loudly rather than produce a wrong value.

```go
// field: OptBool *bool, map: {"opt-bool": "nope"}  (string, not convertible to bool)
// before: OptBool == &false  (non-nil, value silently lost)
// after:  error "flag \"opt-bool\": cannot convert string to bool"
```

## What?

- Compute the conversion target once (element type for pointer fields) and return an error when the present value is not convertible, instead of mis-setting/dropping it ([flags.go](https://github.com/fredrikaverpil/pocket/blob/9bb242b560d9bbe6ea801ac3ac48aa1b4df4f6ca/pk/run/flags.go#L55)).
- The error rides the existing `FlagError` plumbing: `GetFlags` panics `FlagError`, `task.execute` recovers it into `task %q: <err>`.
- `pk/run` had no tests; add table-driven `mapToStruct` coverage, including the two non-convertible cases that previously failed silently and the absent-pointer-key-stays-nil invariant.

## Notes

- Per design decision, the permissive `ConvertibleTo`/`Convert` semantics are unchanged (numeric/duration conversions still work; e.g. `*time.Duration` is registered as `int64` and converted back). Only the non-convertible branch went from silent to loud.
- JSON exec sources flags from existing plan instances (typed structs), not raw JSON, so it cannot introduce untyped values — the new error only fires on a real mismatch.
- REVIEW.md finding 9.