### PR TITLE
docs(pk): fix task execution flow docs

### DIFF
--- a/.claude/skills/pocket-engine/INTERNALS.md
+++ b/.claude/skills/pocket-engine/INTERNALS.md
@@ -119,9 +119,10 @@ pattern.
 task.run(ctx)
     │
     ├── Check manual status (skip if auto-exec and task is manual)
+    ├── Apply TASK_SCOPE visibility filtering for auto-exec
     ├── Build resolved flags (defaults + plan + CLI)
+    ├── Check path mappings and task-specific path exclusions
     ├── Check deduplication (tracker.markDone)
-    ├── Check task-specific path exclusions
     ├── Print header (":: taskname @ path")
     └── Execute (Do function or Body runnable)
 ```


### PR DESCRIPTION
## Why?

- The engine internals docs still showed deduplication before path exclusion.
- The current runtime checks path mappings/exclusions first so excluded paths do not mark tasks as done.

```text
path exclusions -> deduplication
```

## What?

- Update `.claude/skills/pocket-engine/INTERNALS.md` task execution flow.
- Include the `TASK_SCOPE` auto-exec visibility step.

## Notes

- Docs-only change; no tests run beyond `git diff --check`.