### PR TITLE
fix(pk): use per-occurrence path filter resolutions

### DIFF
--- a/.claude/skills/pocket-engine/INTERNALS.md
+++ b/.claude/skills/pocket-engine/INTERNALS.md
@@ -6,7 +6,7 @@
 
 ```go
 type Plan struct {
-    tree              Runnable           // Original composition tree
+    tree              Runnable           // Planned execution tree
     taskInstances     []taskInstance     // Flat list of all tasks
     taskIndex         map[string]*taskInstance  // Lookup by effective name
     pathMappings      map[string]pathInfo       // Task → execution paths
@@ -30,14 +30,16 @@ type taskInstance struct {
 1. **Walk filesystem** — `walkDirectories()` from git root, skipping
    `DefaultSkipDirs` (vendor, node_modules, etc.). Result is cached.
 
-2. **Collect tasks** — `taskCollector` traverses the composition tree. For each
-   `pathFilter` encountered, it pushes scope (include/exclude patterns, flags,
-   context values, name suffix) onto a stack. For each `Task`, it creates a
-   `taskInstance` with the accumulated scope. Repeat occurrences of the same
-   (task, suffix) pair merge into the existing instance: resolved paths are
-   unioned (in `taskInstances` and `pathMappings` alike, so auto execution and
-   direct invocation agree), and conflicting flag overrides across scopes fail
-   plan building.
+2. **Collect tasks and plan execution** — `taskCollector` traverses the
+   composition tree. For each `pathFilter` occurrence, it pushes scope
+   (include/exclude patterns, flags, context values, name suffix) onto a stack
+   and returns a cloned `pathFilter` with that occurrence's resolved paths for
+   the planned execution tree. User-owned composition nodes are never mutated.
+   For each `Task`, it creates a `taskInstance` with the accumulated scope.
+   Repeat occurrences of the same (task, suffix) pair merge into the existing
+   instance: resolved paths are unioned (in `taskInstances` and `pathMappings`
+   alike, so auto execution and direct invocation agree), and conflicting flag
+   overrides across scopes fail plan building.
 
 3. **Resolve paths** — For each task instance, paths are resolved against the
    cached directory list:

--- a/pk/builtins.go
+++ b/pk/builtins.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/fredrikaverpil/pocket/internal/scaffold"
@@ -403,7 +404,7 @@ func printPlanText(ctx context.Context, p *Plan) {
 	}
 
 	pkrun.Printf(ctx, "Composition Tree:\n")
-	printTree(ctx, p.tree, "", true, "", p)
+	printTree(ctx, p.tree, "", true, "", nil, p)
 
 	pkrun.Println(ctx)
 	pkrun.Printf(ctx, "Legend: [→] = Serial, [⚡] = Parallel\n")
@@ -416,6 +417,7 @@ func printTree(
 	prefix string,
 	isLast bool,
 	nameSuffix string,
+	activePaths []string,
 	p *Plan,
 ) {
 	if r == nil {
@@ -448,13 +450,10 @@ func printTree(
 			marker = " [" + strings.Join(markers, ", ") + "]"
 		}
 
-		paths := "[root]"
-		if info, ok := p.pathMappings[effectiveName]; ok {
-			if len(info.resolvedPaths) > 0 {
-				paths = formatPaths(info.resolvedPaths)
-			} else {
-				paths = "[skipped]"
-			}
+		paths := pathsForTreeNode(activePaths, effectiveName, p)
+		pathLabel := "[skipped]"
+		if paths != nil {
+			pathLabel = formatPaths(paths)
 		}
 
 		pkrun.Printf(ctx, "%s%s%s%s\n", prefix, branch, effectiveName, marker)
@@ -463,7 +462,7 @@ func printTree(
 		if isLast {
 			continuation = "    "
 		}
-		pkrun.Printf(ctx, "%s%s    paths: %s\n", prefix, continuation, paths)
+		pkrun.Printf(ctx, "%s%s    paths: %s\n", prefix, continuation, pathLabel)
 
 	case *jsonTaskRef:
 		markers := []string{"task ref"}
@@ -473,20 +472,17 @@ func printTree(
 		if instance := p.taskInstanceByName(v.name); instance != nil && instance.isManual {
 			markers = append(markers, "manual")
 		}
-		paths := "[root]"
-		if info, ok := p.pathMappings[v.name]; ok {
-			if len(info.resolvedPaths) > 0 {
-				paths = formatPaths(info.resolvedPaths)
-			} else {
-				paths = "[skipped]"
-			}
+		paths := pathsForTreeNode(activePaths, v.name, p)
+		pathLabel := "[skipped]"
+		if paths != nil {
+			pathLabel = formatPaths(paths)
 		}
 		pkrun.Printf(ctx, "%s%s%s [%s]\n", prefix, branch, v.name, strings.Join(markers, ", "))
 		continuation := "│   "
 		if isLast {
 			continuation = "    "
 		}
-		pkrun.Printf(ctx, "%s%s    paths: %s\n", prefix, continuation, paths)
+		pkrun.Printf(ctx, "%s%s    paths: %s\n", prefix, continuation, pathLabel)
 
 	case *serial:
 		pkrun.Printf(ctx, "%s%s[→] Serial\n", prefix, branch)
@@ -497,7 +493,7 @@ func printTree(
 			childPrefix += "│   "
 		}
 		for i, child := range v.runnables {
-			printTree(ctx, child, childPrefix, i == len(v.runnables)-1, nameSuffix, p)
+			printTree(ctx, child, childPrefix, i == len(v.runnables)-1, nameSuffix, activePaths, p)
 		}
 
 	case *parallel:
@@ -509,7 +505,7 @@ func printTree(
 			childPrefix += "│   "
 		}
 		for i, child := range v.runnables {
-			printTree(ctx, child, childPrefix, i == len(v.runnables)-1, nameSuffix, p)
+			printTree(ctx, child, childPrefix, i == len(v.runnables)-1, nameSuffix, activePaths, p)
 		}
 
 	case *pathFilter:
@@ -520,6 +516,11 @@ func printTree(
 			} else {
 				childSuffix = v.nameSuffix
 			}
+		}
+
+		paths := slices.Clone(v.resolvedPaths)
+		if activePaths != nil {
+			paths = intersectPaths(activePaths, paths)
 		}
 
 		hasPathOptions := len(v.includePaths) > 0 || len(v.excludePaths) > 0 ||
@@ -538,11 +539,25 @@ func printTree(
 			if len(v.excludePaths) > 0 {
 				pkrun.Printf(ctx, "%s    exclude: %v\n", childPrefix, v.excludePaths)
 			}
-			printTree(ctx, v.inner, childPrefix, true, childSuffix, p)
+			printTree(ctx, v.inner, childPrefix, true, childSuffix, paths, p)
 		} else {
-			printTree(ctx, v.inner, prefix, isLast, childSuffix, p)
+			printTree(ctx, v.inner, prefix, isLast, childSuffix, paths, p)
 		}
 	}
+}
+
+func pathsForTreeNode(activePaths []string, taskName string, p *Plan) []string {
+	paths := []string{"."}
+	if activePaths != nil {
+		paths = slices.Clone(activePaths)
+	}
+	if info, ok := p.pathMappings[taskName]; ok {
+		if len(info.resolvedPaths) == 0 {
+			return nil
+		}
+		paths = intersectPaths(paths, info.resolvedPaths)
+	}
+	return paths
 }
 
 // formatPaths formats a path list for display.

--- a/pk/builtins_test.go
+++ b/pk/builtins_test.go
@@ -218,7 +218,7 @@ func TestPrintTree(t *testing.T) {
 	out := &pkrun.Output{Stdout: &buf, Stderr: &buf}
 	ctx := context.WithValue(context.Background(), ctxkey.Output{}, out)
 
-	printTree(ctx, plan.tree, "", true, "", plan)
+	printTree(ctx, plan.tree, "", true, "", nil, plan)
 
 	output := buf.String()
 	if !bytes.Contains([]byte(output), []byte("test")) {

--- a/pk/cli.go
+++ b/pk/cli.go
@@ -152,7 +152,7 @@ func run(cfg *Config) (*executionTracker, error) {
 	}
 
 	// Execute the full configuration with pre-built Plan.
-	return executeAll(ctx, *cfg, plan)
+	return executeAll(ctx, plan)
 }
 
 // findTask looks up a task by name, checking builtins first then user tasks.
@@ -295,8 +295,8 @@ func (inst *taskInstance) execute(ctx context.Context) error {
 	return nil
 }
 
-func executeAll(ctx context.Context, c Config, p *Plan) (*executionTracker, error) {
-	if c.Auto == nil || p == nil {
+func executeAll(ctx context.Context, p *Plan) (*executionTracker, error) {
+	if p == nil || p.tree == nil {
 		return nil, nil
 	}
 
@@ -309,7 +309,7 @@ func executeAll(ctx context.Context, c Config, p *Plan) (*executionTracker, erro
 	tracker := newExecutionTracker()
 	ctx = withExecutionTracker(ctx, tracker)
 	ctx = context.WithValue(ctx, ctxkey.AutoExec{}, true)
-	if err := c.Auto.run(ctx); err != nil {
+	if err := p.tree.run(ctx); err != nil {
 		return tracker, err
 	}
 

--- a/pk/e2e_test.go
+++ b/pk/e2e_test.go
@@ -383,7 +383,7 @@ func TestE2E_AutoExec_SerialOrder(t *testing.T) {
 
 	ctx := e2eCtx(t, plan)
 	ctx = context.WithValue(ctx, ctxkey.AutoExec{}, true)
-	if err := cfg.Auto.run(ctx); err != nil {
+	if err := plan.tree.run(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -410,7 +410,7 @@ func TestE2E_AutoExec_ParallelAll(t *testing.T) {
 
 	ctx := e2eCtx(t, plan)
 	ctx = context.WithValue(ctx, ctxkey.AutoExec{}, true)
-	if err := cfg.Auto.run(ctx); err != nil {
+	if err := plan.tree.run(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -441,7 +441,7 @@ func TestE2E_AutoExec_MixedComposition(t *testing.T) {
 
 	ctx := e2eCtx(t, plan)
 	ctx = context.WithValue(ctx, ctxkey.AutoExec{}, true)
-	if err := cfg.Auto.run(ctx); err != nil {
+	if err := plan.tree.run(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -477,7 +477,7 @@ func TestE2E_AutoExec_SerialStopsOnError(t *testing.T) {
 
 	ctx := e2eCtx(t, plan)
 	ctx = context.WithValue(ctx, ctxkey.AutoExec{}, true)
-	err = cfg.Auto.run(ctx)
+	err = plan.tree.run(ctx)
 	if err == nil {
 		t.Fatal("expected error from failing task")
 	}
@@ -517,7 +517,7 @@ func TestE2E_AutoExec_ManualSkipped(t *testing.T) {
 	ctx = context.WithValue(ctx, ctxkey.AutoExec{}, true)
 
 	// Run auto tree.
-	if err := cfg.Auto.run(ctx); err != nil {
+	if err := plan.tree.run(ctx); err != nil {
 		t.Fatal(err)
 	}
 	// Attempt to run manual task in auto-exec context.
@@ -551,7 +551,7 @@ func TestE2E_AutoExec_Deduplication(t *testing.T) {
 
 	ctx := e2eCtx(t, plan)
 	ctx = context.WithValue(ctx, ctxkey.AutoExec{}, true)
-	if err := cfg.Auto.run(ctx); err != nil {
+	if err := plan.tree.run(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -593,7 +593,7 @@ func TestE2E_AutoExec_PathFilterWithDetect(t *testing.T) {
 
 	ctx := e2eCtx(t, plan)
 	ctx = context.WithValue(ctx, ctxkey.AutoExec{}, true)
-	if err := cfg.Auto.run(ctx); err != nil {
+	if err := plan.tree.run(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -637,7 +637,7 @@ func TestE2E_AutoExec_TaskScope(t *testing.T) {
 
 	ctx := e2eCtx(t, plan)
 	ctx = context.WithValue(ctx, ctxkey.AutoExec{}, true)
-	if err := cfg.Auto.run(ctx); err != nil {
+	if err := plan.tree.run(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -669,7 +669,7 @@ func TestE2E_AutoExec_TaskInMultipleScopes(t *testing.T) {
 
 	ctx := e2eCtx(t, plan)
 	ctx = context.WithValue(ctx, ctxkey.AutoExec{}, true)
-	if err := cfg.Auto.run(ctx); err != nil {
+	if err := plan.tree.run(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -750,7 +750,7 @@ func TestE2E_AutoExec_GlobalTaskExcludedPathStillRunsElsewhere(t *testing.T) {
 
 	ctx := e2eCtx(t, plan)
 	ctx = context.WithValue(ctx, ctxkey.AutoExec{}, true)
-	if err := cfg.Auto.run(ctx); err != nil {
+	if err := plan.tree.run(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -784,7 +784,7 @@ func TestE2E_AutoExec_NestedScopesWithForceRun(t *testing.T) {
 
 	ctx := e2eCtx(t, plan)
 	ctx = context.WithValue(ctx, ctxkey.AutoExec{}, true)
-	if err := cfg.Auto.run(ctx); err != nil {
+	if err := plan.tree.run(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -826,7 +826,7 @@ func TestE2E_AutoExec_NestedScopeFollowsOuterIteration(t *testing.T) {
 
 	ctx := e2eCtx(t, plan)
 	ctx = context.WithValue(ctx, ctxkey.AutoExec{}, true)
-	if err := cfg.Auto.run(ctx); err != nil {
+	if err := plan.tree.run(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -869,7 +869,7 @@ func TestE2E_AutoExec_ReusedScopeKeepsAllPaths(t *testing.T) {
 
 	ctx := e2eCtx(t, plan)
 	ctx = context.WithValue(ctx, ctxkey.AutoExec{}, true)
-	if err := cfg.Auto.run(ctx); err != nil {
+	if err := plan.tree.run(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -879,6 +879,53 @@ func TestE2E_AutoExec_ReusedScopeKeepsAllPaths(t *testing.T) {
 	want := []execRecord{
 		{TaskName: "reused", Path: "svc-a"},
 		{TaskName: "reused", Path: "svc-b"},
+	}
+	assert.DeepEqual(t, rec.records, want)
+}
+
+func TestE2E_AutoExec_ReusedScopeResolutionIsPerOccurrence(t *testing.T) {
+	tmpDir := e2eSetup(t)
+	if err := os.MkdirAll(filepath.Join(tmpDir, "svc-a"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := newRecorder()
+	test := rec.task("test")
+	install := rec.task("install")
+
+	// The same WithOptions value appears first at the top level (root-only),
+	// then under a svc-a scope. The top-level occurrence must not inherit the
+	// nested occurrence's path, or it would run test@svc-a before install@svc-a.
+	shared := WithOptions(test)
+	cfg := &Config{
+		Auto: Serial(
+			shared,
+			WithOptions(
+				Serial(install, shared),
+				WithPath("svc-a"),
+			),
+		),
+	}
+	plan, err := newPublicPlan(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Plan building must not write resolution data onto the user-owned node.
+	if got := shared.(*pathFilter).resolvedPaths; got != nil {
+		t.Fatalf("shared resolvedPaths = %v, want nil", got)
+	}
+
+	ctx := e2eCtx(t, plan)
+	ctx = context.WithValue(ctx, ctxkey.AutoExec{}, true)
+	if err := plan.tree.run(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []execRecord{
+		{TaskName: "test", Path: "."},
+		{TaskName: "install", Path: "svc-a"},
+		{TaskName: "test", Path: "svc-a"},
 	}
 	assert.DeepEqual(t, rec.records, want)
 }
@@ -924,7 +971,7 @@ func TestE2E_AutoExec_ReusedDetectScopeKeepsAllPaths(t *testing.T) {
 
 	ctx := e2eCtx(t, plan)
 	ctx = context.WithValue(ctx, ctxkey.AutoExec{}, true)
-	if err := cfg.Auto.run(ctx); err != nil {
+	if err := plan.tree.run(ctx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pk/execjson.go
+++ b/pk/execjson.go
@@ -481,7 +481,7 @@ func emitInvocationJSON(ctx context.Context, p *Plan, taskName string, w io.Writ
 		if p.tree == nil {
 			tree = map[string]any{"type": jsonNodeTypeSerial, "children": []map[string]any{}}
 		} else {
-			tree = emitJSONNode(p.tree, "", p)
+			tree = emitJSONNode(p.tree, "", nil, p)
 		}
 	} else {
 		inst := p.taskInstanceByName(taskName)
@@ -511,7 +511,7 @@ func emitInvocationJSON(ctx context.Context, p *Plan, taskName string, w io.Writ
 }
 
 // emitJSONNode converts a Runnable to its JSON representation.
-func emitJSONNode(r Runnable, nameSuffix string, p *Plan) map[string]any {
+func emitJSONNode(r Runnable, nameSuffix string, activePaths []string, p *Plan) map[string]any {
 	switch v := r.(type) {
 	case *Task:
 		effectiveName := v.Name
@@ -519,8 +519,11 @@ func emitJSONNode(r Runnable, nameSuffix string, p *Plan) map[string]any {
 			effectiveName = v.Name + ":" + nameSuffix
 		}
 		paths := []string{"."}
+		if activePaths != nil {
+			paths = slices.Clone(activePaths)
+		}
 		if info, ok := p.pathMappings[effectiveName]; ok && len(info.resolvedPaths) > 0 {
-			paths = info.resolvedPaths
+			paths = intersectPaths(paths, info.resolvedPaths)
 		}
 		return map[string]any{
 			"type":  jsonNodeTypeTask,
@@ -530,13 +533,13 @@ func emitJSONNode(r Runnable, nameSuffix string, p *Plan) map[string]any {
 	case *serial:
 		children := make([]map[string]any, 0, len(v.runnables))
 		for _, child := range v.runnables {
-			children = append(children, emitJSONNode(child, nameSuffix, p))
+			children = append(children, emitJSONNode(child, nameSuffix, activePaths, p))
 		}
 		return map[string]any{"type": jsonNodeTypeSerial, "children": children}
 	case *parallel:
 		children := make([]map[string]any, 0, len(v.runnables))
 		for _, child := range v.runnables {
-			children = append(children, emitJSONNode(child, nameSuffix, p))
+			children = append(children, emitJSONNode(child, nameSuffix, activePaths, p))
 		}
 		return map[string]any{"type": jsonNodeTypeParallel, "children": children}
 	case *pathFilter:
@@ -548,7 +551,11 @@ func emitJSONNode(r Runnable, nameSuffix string, p *Plan) map[string]any {
 				childSuffix = v.nameSuffix
 			}
 		}
-		return emitJSONNode(v.inner, childSuffix, p)
+		paths := slices.Clone(v.resolvedPaths)
+		if activePaths != nil {
+			paths = intersectPaths(activePaths, paths)
+		}
+		return emitJSONNode(v.inner, childSuffix, paths, p)
 	}
 	return map[string]any{}
 }

--- a/pk/execjson_test.go
+++ b/pk/execjson_test.go
@@ -510,6 +510,61 @@ func TestEmitInvocationJSON_FullTree(t *testing.T) {
 	}
 }
 
+func TestEmitInvocationJSON_ReusedScopeUsesOccurrencePaths(t *testing.T) {
+	test := &Task{Name: "test", Usage: "test", Do: func(_ context.Context) error { return nil }}
+	install := &Task{Name: "install", Usage: "install", Do: func(_ context.Context) error { return nil }}
+	shared := WithOptions(test)
+	cfg := &Config{
+		Auto: Serial(
+			shared,
+			WithOptions(
+				Serial(install, shared),
+				WithPath("svc-a"),
+			),
+		),
+	}
+	plan, err := newPlan(cfg, "/tmp", []string{".", "svc-a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := emitInvocationJSON(context.Background(), plan, "", &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("emitted JSON does not parse: %v\n%s", err, buf.String())
+	}
+	root := doc["tree"].(map[string]any)
+	children := root["children"].([]any)
+	firstTest := children[0].(map[string]any)
+	if got := jsonStringSlice(firstTest["paths"]); !slices.Equal(got, []string{"."}) {
+		t.Fatalf("first test paths = %v, want [.]", got)
+	}
+
+	nested := children[1].(map[string]any)
+	nestedChildren := nested["children"].([]any)
+	nestedInstall := nestedChildren[0].(map[string]any)
+	if got := jsonStringSlice(nestedInstall["paths"]); !slices.Equal(got, []string{"svc-a"}) {
+		t.Fatalf("nested install paths = %v, want [svc-a]", got)
+	}
+	nestedTest := nestedChildren[1].(map[string]any)
+	if got := jsonStringSlice(nestedTest["paths"]); !slices.Equal(got, []string{"svc-a"}) {
+		t.Fatalf("nested test paths = %v, want [svc-a]", got)
+	}
+}
+
+func jsonStringSlice(v any) []string {
+	values := v.([]any)
+	result := make([]string, len(values))
+	for i, value := range values {
+		result[i] = value.(string)
+	}
+	return result
+}
+
 func TestEmitInvocationJSON_SingleTask(t *testing.T) {
 	task := &Task{Name: "lint", Usage: "lint", Do: func(_ context.Context) error { return nil }}
 	cfg := &Config{Auto: Serial(task)}

--- a/pk/integration_test.go
+++ b/pk/integration_test.go
@@ -39,7 +39,7 @@ func TestIntegration_SerialOrder(t *testing.T) {
 	}
 
 	ctx, _ := integrationCtx(t, plan)
-	if err := cfg.Auto.run(ctx); err != nil {
+	if err := plan.tree.run(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -80,7 +80,7 @@ func TestIntegration_MixedComposition(t *testing.T) {
 	}
 
 	ctx, _ := integrationCtx(t, plan)
-	if err := cfg.Auto.run(ctx); err != nil {
+	if err := plan.tree.run(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -124,7 +124,7 @@ func TestIntegration_PathFilterWithDetect(t *testing.T) {
 	}
 
 	ctx, _ := integrationCtx(t, plan)
-	if err := cfg.Auto.run(ctx); err != nil {
+	if err := plan.tree.run(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -149,7 +149,7 @@ func TestIntegration_DeduplicationAcrossComposition(t *testing.T) {
 	}
 
 	ctx, _ := integrationCtx(t, plan)
-	if err := cfg.Auto.run(ctx); err != nil {
+	if err := plan.tree.run(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -196,7 +196,7 @@ func TestIntegration_WithNameSuffix_MultiVersion(t *testing.T) {
 	}
 
 	ctx, _ := integrationCtx(t, plan)
-	if err := cfg.Auto.run(ctx); err != nil {
+	if err := plan.tree.run(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -235,7 +235,7 @@ func TestIntegration_WithSkipTaskPattern(t *testing.T) {
 	}
 
 	ctx, _ := integrationCtx(t, plan)
-	if err := cfg.Auto.run(ctx); err != nil {
+	if err := plan.tree.run(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -254,9 +254,10 @@ func TestIntegration_WithSkipTaskPattern(t *testing.T) {
 }
 
 func TestIntegration_WithSkipTask(t *testing.T) {
-	a := &Task{Name: "a", Usage: "a", Do: func(_ context.Context) error { return nil }}
-	b := &Task{Name: "b", Usage: "b", Do: func(_ context.Context) error { return nil }}
-	c := &Task{Name: "c", Usage: "c", Do: func(_ context.Context) error { return nil }}
+	var ran []string
+	a := &Task{Name: "a", Usage: "a", Do: func(_ context.Context) error { ran = append(ran, "a"); return nil }}
+	b := &Task{Name: "b", Usage: "b", Do: func(_ context.Context) error { ran = append(ran, "b"); return nil }}
+	c := &Task{Name: "c", Usage: "c", Do: func(_ context.Context) error { ran = append(ran, "c"); return nil }}
 
 	cfg := &Config{
 		Auto: WithOptions(
@@ -285,6 +286,14 @@ func TestIntegration_WithSkipTask(t *testing.T) {
 	}
 	if !names["a"] || !names["c"] {
 		t.Errorf("expected a and c in plan, got %v", names)
+	}
+
+	ctx, _ := integrationCtx(t, plan)
+	if err := plan.tree.run(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if len(ran) != 2 || ran[0] != "a" || ran[1] != "c" {
+		t.Errorf("expected only a and c to run, got %v", ran)
 	}
 }
 
@@ -315,7 +324,7 @@ func TestIntegration_ManualTaskSkippedInAutoExec(t *testing.T) {
 	ctx = context.WithValue(ctx, ctxkey.AutoExec{}, true)
 
 	// Run auto tree.
-	if err := cfg.Auto.run(ctx); err != nil {
+	if err := plan.tree.run(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -358,7 +367,7 @@ func TestIntegration_FlagOverrideViaWithFlag(t *testing.T) {
 	}
 
 	ctx, _ := integrationCtx(t, plan)
-	if err := cfg.Auto.run(ctx); err != nil {
+	if err := plan.tree.run(ctx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pk/options.go
+++ b/pk/options.go
@@ -198,8 +198,9 @@ type pathFilter struct {
 	flags        []flagOverride
 	nameSuffix   string     // Suffix to append to task names (e.g., ":3.9").
 	detectFunc   DetectFunc // Optional detection function for dynamic path discovery.
-	// resolvedPaths holds resolved paths for engine-constructed filters (e.g.
-	// JSON commands). Walked filters use Plan.pfResolved instead.
+	// resolvedPaths holds resolved paths for planned execution-tree filters and
+	// engine-constructed filters (e.g. JSON commands). Plan building sets this on
+	// cloned filters, never on user-owned WithOptions values.
 	resolvedPaths []string
 
 	forceRun       bool     // Disable task deduplication for the wrapped Runnable.
@@ -222,8 +223,7 @@ type flagOverride struct {
 
 // run implements the Runnable interface.
 // It executes the inner Runnable for each resolved path.
-// Paths are resolved during plan building and recorded in Plan.pfResolved
-// (engine-constructed filters fall back to the resolvedPaths field).
+// Paths are resolved during plan building and stored on the planned filter.
 // Flag overrides are pre-computed during planning and read from Plan.taskInstanceByName().
 func (pf *pathFilter) run(ctx context.Context) error {
 	// If forceRun is set, propagate it to the context.
@@ -241,15 +241,11 @@ func (pf *pathFilter) run(ctx context.Context) error {
 		ctx = context.WithValue(ctx, ctxkey.NoticePatterns{}, pf.noticePatterns)
 	}
 
-	// Walked filters read their resolved paths from the Plan (keyed by this
-	// pathFilter), so plan building never mutates the shared composition node.
-	// Engine-constructed filters (e.g. JSON commands) carry their own field.
-	paths := pf.resolvedPaths
-	if p := planFromContext(ctx); p != nil {
-		if walked, ok := p.pfResolved[pf]; ok {
-			paths = walked
-		}
+	if pf.inner == nil {
+		return nil
 	}
+
+	paths := pf.resolvedPaths
 
 	// An enclosing pathFilter has already selected a directory for this pass.
 	// Nested scopes refine outer scopes, so narrow to that directory instead of

--- a/pk/plan.go
+++ b/pk/plan.go
@@ -30,8 +30,9 @@ func planFromContext(ctx context.Context) *Plan {
 // Use [Plan.Tasks] to inspect what will execute, and [PlanFromContext]
 // to access the plan from within a task's Do function.
 type Plan struct {
-	// tree is the composition tree that preserves dependencies and structure.
-	// Execution walks this tree, respecting Serial/Parallel composition.
+	// tree is the planned execution tree that preserves dependencies and structure.
+	// It clones pathFilter nodes with per-occurrence resolved paths so execution
+	// does not mutate or depend on user-owned composition nodes.
 	// This is exposed as a Runnable, but the concrete types are internal.
 	tree Runnable
 
@@ -54,14 +55,6 @@ type Plan struct {
 
 	// shimConfig holds the shim generation configuration from Config.
 	shimConfig *ShimConfig
-
-	// pfResolved maps each pathFilter in the composition tree to the directories
-	// it executes in. Resolution results are stored here rather than on the
-	// pathFilter itself so that plan building never mutates the user's shared
-	// composition nodes: the same WithOptions value referenced from multiple tree
-	// positions accumulates (unions) its paths here instead of overwriting a
-	// field. Read at execution time by pathFilter.run via the Plan in context.
-	pfResolved map[*pathFilter][]string
 }
 
 // ShimConfig returns the resolved shim configuration from the [Config].
@@ -144,15 +137,18 @@ func newPlan(cfg *Config, gitRoot string, allDirs []string) (*Plan, error) {
 		taskInstances: make([]taskInstance, 0),
 		seenTasks:     make(map[taskKey]int),
 		pathMappings:  make(map[string]pathInfo),
-		pfResolved:    make(map[*pathFilter][]string),
 		currentPath:   nil,
 		gitRoot:       gitRoot,
 		allDirs:       allDirs,
 	}
 
-	// Walk the Auto tree
+	// Walk the Auto tree and build a planned execution tree with per-occurrence
+	// pathFilter resolutions.
+	var tree Runnable
 	if cfg.Auto != nil {
-		if err := collector.walk(cfg.Auto); err != nil {
+		var err error
+		tree, err = collector.walk(cfg.Auto)
+		if err != nil {
 			return nil, err
 		}
 	}
@@ -160,7 +156,7 @@ func newPlan(cfg *Config, gitRoot string, allDirs []string) (*Plan, error) {
 	// Walk manual tasks - tasks in Config.Manual are automatically marked manual.
 	collector.inManualSection = true
 	for _, r := range cfg.Manual {
-		if err := collector.walk(r); err != nil {
+		if _, err := collector.walk(r); err != nil {
 			return nil, err
 		}
 	}
@@ -180,13 +176,12 @@ func newPlan(cfg *Config, gitRoot string, allDirs []string) (*Plan, error) {
 	}
 
 	return &Plan{
-		tree:              cfg.Auto, // Preserve the composition tree!
+		tree:              tree,
 		taskInstances:     collector.taskInstances,
 		taskIndex:         taskIndex,
 		pathMappings:      collector.pathMappings,
 		moduleDirectories: moduleDirectories,
 		shimConfig:        shimConfig,
-		pfResolved:        collector.pfResolved,
 	}, nil
 }
 
@@ -205,13 +200,12 @@ type taskInstance struct {
 
 // taskCollector is the internal state for walking the tree.
 type taskCollector struct {
-	taskInstances []taskInstance           // Tasks with their effective names.
-	seenTasks     map[taskKey]int          // Maps seen (task, suffix) pairs to their taskInstances index.
-	pathMappings  map[string]pathInfo      // Per-task execution paths by effective name.
-	pfResolved    map[*pathFilter][]string // Resolved paths per pathFilter (unioned across occurrences).
-	currentPath   *pathFilter              // Current path context during tree walk.
-	gitRoot       string                   // Git repository root.
-	allDirs       []string                 // Cached directory list from filesystem walk.
+	taskInstances []taskInstance      // Tasks with their effective names.
+	seenTasks     map[taskKey]int     // Maps seen (task, suffix) pairs to their taskInstances index.
+	pathMappings  map[string]pathInfo // Per-task execution paths by effective name.
+	currentPath   *pathFilter         // Current path context during tree walk.
+	gitRoot       string              // Git repository root.
+	allDirs       []string            // Cached directory list from filesystem walk.
 
 	// Cumulative state
 	candidates       []string         // Current allowed directories.
@@ -283,10 +277,12 @@ func (pc *taskCollector) filterPaths(pf *pathFilter) ([]string, error) {
 	return results, nil
 }
 
-// walk recursively traverses the Runnable tree.
-func (pc *taskCollector) walk(r Runnable) error {
+// walk recursively traverses the Runnable tree and returns the planned
+// execution tree for the same occurrence. The returned tree reuses task nodes
+// but clones composition nodes so pathFilter resolutions are per occurrence.
+func (pc *taskCollector) walk(r Runnable) (Runnable, error) {
 	if r == nil {
-		return nil
+		return nil, nil
 	}
 
 	// Initialize candidates if this is the root call.
@@ -299,29 +295,29 @@ func (pc *taskCollector) walk(r Runnable) error {
 	case *Task:
 		// Validate task during plan building.
 		if v.Name == "" {
-			return fmt.Errorf("task has empty Name")
+			return nil, fmt.Errorf("task has empty Name")
 		}
 		if v.Do == nil && v.Body == nil {
-			return fmt.Errorf("task %q: must set either Do or Body", v.Name)
+			return nil, fmt.Errorf("task %q: must set either Do or Body", v.Name)
 		}
 		if v.Do != nil && v.Body != nil {
-			return fmt.Errorf("task %q: Do and Body are mutually exclusive", v.Name)
+			return nil, fmt.Errorf("task %q: Do and Body are mutually exclusive", v.Name)
 		}
 		if v.Body != nil {
 			if err := validateBodyComposition(v.Name, v.Body); err != nil {
-				return err
+				return nil, err
 			}
 		}
 		// Build internal flagSet if not already built.
 		if v.flagSet == nil {
 			if err := v.buildFlagSet(); err != nil {
-				return err
+				return nil, err
 			}
 		}
 
 		// Check if task is skipped in current scope.
 		if slices.Contains(pc.activeSkips, v.Name) {
-			return nil
+			return nil, nil
 		}
 
 		// Build effective name with suffix (e.g., "py-test:3.9").
@@ -348,7 +344,7 @@ func (pc *taskCollector) walk(r Runnable) error {
 					var err error
 					finalPaths, err = excludeByPatterns(finalPaths, []string{ex.pattern})
 					if err != nil {
-						return err
+						return nil, err
 					}
 				}
 			}
@@ -357,7 +353,7 @@ func (pc *taskCollector) walk(r Runnable) error {
 			// This likely indicates a misconfiguration where the user is running tasks
 			// but excluding all directories that would match.
 			if len(finalPaths) == 0 && len(pc.candidates) > 0 {
-				return fmt.Errorf("task %q: excludes removed all %d detected path(s); "+
+				return nil, fmt.Errorf("task %q: excludes removed all %d detected path(s); "+
 					"either adjust excludes or use WithSkipTask to remove this task entirely",
 					effectiveName, len(pc.candidates))
 			}
@@ -369,7 +365,7 @@ func (pc *taskCollector) walk(r Runnable) error {
 					var err error
 					finalPaths, err = excludeByPatterns(finalPaths, []string{ex.pattern})
 					if err != nil {
-						return err
+						return nil, err
 					}
 				}
 			}
@@ -394,7 +390,7 @@ func (pc *taskCollector) walk(r Runnable) error {
 		if idx, seen := pc.seenTasks[key]; seen {
 			instance := &pc.taskInstances[idx]
 			if !reflect.DeepEqual(instance.flags, mergedFlags) {
-				return fmt.Errorf(
+				return nil, fmt.Errorf(
 					"task %q: conflicting flag overrides across scopes (%v vs %v); "+
 						"use WithNameSuffix to create distinct variants",
 					effectiveName, instance.flags, mergedFlags)
@@ -440,33 +436,42 @@ func (pc *taskCollector) walk(r Runnable) error {
 			resolvedPaths: finalPaths,
 		}
 
+		return v, nil
+
 	case *serial:
+		children := make([]Runnable, 0, len(v.runnables))
 		for _, child := range v.runnables {
-			if err := pc.walk(child); err != nil {
-				return err
+			plannedChild, err := pc.walk(child)
+			if err != nil {
+				return nil, err
+			}
+			if plannedChild != nil {
+				children = append(children, plannedChild)
 			}
 		}
+		return &serial{runnables: children}, nil
 
 	case *parallel:
+		children := make([]Runnable, 0, len(v.runnables))
 		for _, child := range v.runnables {
-			if err := pc.walk(child); err != nil {
-				return err
+			plannedChild, err := pc.walk(child)
+			if err != nil {
+				return nil, err
+			}
+			if plannedChild != nil {
+				children = append(children, plannedChild)
 			}
 		}
+		return &parallel{runnables: children}, nil
 
 	case *pathFilter:
-		// 1. Resolve paths for this filter based on current candidates.
-		// Store the result in the Plan (keyed by this pathFilter) rather than on
-		// the node itself: the same WithOptions value may appear at multiple tree
-		// positions, so occurrences union their paths here instead of the last
-		// walk overwriting a shared field. The union is a correct superset at
-		// execution time — pathFilter.run iterates it at the top level and narrows
-		// to a single enclosing directory when nested.
+		// 1. Resolve paths for this occurrence based on current candidates. The
+		// user-owned pathFilter is not mutated; a cloned filter carrying this
+		// occurrence's resolution is returned for the planned execution tree.
 		resolved, err := pc.filterPaths(v)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		pc.pfResolved[v] = unionPaths(pc.pfResolved[v], resolved)
 
 		// 2. Save state for nesting.
 		prevCandidates := pc.candidates
@@ -481,7 +486,7 @@ func (pc *taskCollector) walk(r Runnable) error {
 		// Resolve type-based flag overrides against the inner runnable.
 		resolvedFlags, err := resolveTypedFlags(v.flags, v.inner)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		// 3. Update state with new constraints.
@@ -503,8 +508,9 @@ func (pc *taskCollector) walk(r Runnable) error {
 		}
 
 		// 4. Walk inner with cumulative state.
-		if err := pc.walk(v.inner); err != nil {
-			return err
+		plannedInner, err := pc.walk(v.inner)
+		if err != nil {
+			return nil, err
 		}
 
 		// 5. Restore state.
@@ -517,11 +523,17 @@ func (pc *taskCollector) walk(r Runnable) error {
 		pc.activeFlags = prevFlags
 		pc.activeVerbose = prevVerbose
 
+		if plannedInner == nil {
+			return nil, nil
+		}
+		plannedFilter := *v
+		plannedFilter.inner = plannedInner
+		plannedFilter.resolvedPaths = resolved
+		return &plannedFilter, nil
+
 	default:
 		panic(fmt.Sprintf("pk: unknown Runnable type %T in walk", r))
 	}
-
-	return nil
 }
 
 // validateBodyComposition rejects pathFilters anywhere inside a Task.Body. A
@@ -565,6 +577,18 @@ func unionPaths(base, extra []string) []string {
 	for _, p := range extra {
 		if !slices.Contains(result, p) {
 			result = append(result, p)
+		}
+	}
+	return result
+}
+
+// intersectPaths returns paths from base that are present in allowed, preserving
+// base order.
+func intersectPaths(base, allowed []string) []string {
+	result := make([]string, 0, len(base))
+	for _, path := range base {
+		if slices.Contains(allowed, path) {
+			result = append(result, path)
 		}
 	}
 	return result

--- a/pk/task_test.go
+++ b/pk/task_test.go
@@ -650,7 +650,7 @@ func TestTask_Parallel_WithNameSuffix_FlagRace(t *testing.T) {
 	ctx = context.WithValue(ctx, ctxkey.Plan{}, plan)
 	ctx = context.WithValue(ctx, ctxkey.Output{}, pkrun.StdOutput())
 
-	if err := cfg.Auto.run(ctx); err != nil {
+	if err := plan.tree.run(ctx); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
## Why?

- The #107 fix stored pathFilter resolutions by shared `*pathFilter` pointer.
- Reusing the same `WithOptions(...)` value at different tree positions could widen an earlier occurrence and change execution order.

```go
shared := pk.WithOptions(test)
pk.Serial(
    shared, // should run only at root
    pk.WithOptions(pk.Serial(install, shared), pk.WithPath("svc-a")),
)
```

## What?

- Build `Plan.tree` as a planned execution tree with cloned pathFilter nodes carrying per-occurrence resolved paths.
- Execute auto runs through `Plan.tree` instead of the user-owned `Config.Auto` tree.
- Keep user-owned `WithOptions` nodes unmodified.
- Make plan/JSON rendering use occurrence paths instead of task-wide union paths.
- Add regression coverage for reused scopes and emitted JSON paths.

## Notes

- Tests: `go test ./...`, `go test -race ./pk ./pk/run`, `git diff --check`.