### PR TITLE
fix(run): handle Windows Path environment variable

### DIFF
--- a/pk/exec_test.go
+++ b/pk/exec_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
-	"strings"
 	"testing"
 
 	"github.com/fredrikaverpil/pocket/pk/repopath"
@@ -193,17 +192,12 @@ func TestPrependBinToPath(t *testing.T) {
 	repopath.SetGitRootFunc(func() string { return "/repo" })
 	defer repopath.SetGitRootFunc(nil)
 
-	environ := []string{"HOME=/home/user", pathEnvKeyForTest() + "=/usr/bin:/usr/local/bin"}
-	got := pkrun.PrependBinToPath(environ)
+	got := pkrun.PrependBinToPath([]string{"HOME=/home/user", pathEnvKeyForTest() + "=/usr/bin:/usr/local/bin"})
 
-	pathValue, ok := pathValueFromEnvForTest(got)
-	if !ok {
-		t.Fatal("PATH not found in result")
-	}
-
-	binDir := filepath.Join("/repo", ".pocket", "bin")
-	if !strings.HasPrefix(pathValue, binDir) {
-		t.Errorf("expected PATH to start with %q, got %q", binDir, pathValue)
+	want := pathEnvKeyForTest() + "=" + filepath.Join("/repo", ".pocket", "bin") +
+		string(filepath.ListSeparator) + "/usr/bin:/usr/local/bin"
+	if got[1] != want {
+		t.Errorf("expected PATH entry %q, got %q", want, got[1])
 	}
 }
 
@@ -213,14 +207,9 @@ func TestPrependBinToPath_AddsPathWhenMissing(t *testing.T) {
 
 	got := pkrun.PrependBinToPath([]string{"HOME=/home/user"})
 
-	pathValue, ok := pathValueFromEnvForTest(got)
-	if !ok {
-		t.Fatal("PATH not found in result")
-	}
-
-	want := filepath.Join("/repo", ".pocket", "bin")
-	if pathValue != want {
-		t.Errorf("expected PATH %q, got %q", want, pathValue)
+	want := "PATH=" + filepath.Join("/repo", ".pocket", "bin")
+	if got[len(got)-1] != want {
+		t.Errorf("expected PATH entry %q, got %q", want, got[len(got)-1])
 	}
 }
 
@@ -229,20 +218,4 @@ func pathEnvKeyForTest() string {
 		return "Path"
 	}
 	return "PATH"
-}
-
-func pathValueFromEnvForTest(environ []string) (string, bool) {
-	for _, envEntry := range environ {
-		key, value, ok := strings.Cut(envEntry, "=")
-		if !ok {
-			continue
-		}
-		if runtime.GOOS == "windows" && strings.EqualFold(key, "PATH") {
-			return value, true
-		}
-		if key == "PATH" {
-			return value, true
-		}
-	}
-	return "", false
 }

--- a/pk/exec_test.go
+++ b/pk/exec_test.go
@@ -170,6 +170,21 @@ func TestLookPathInEnv(t *testing.T) {
 		}
 	})
 
+	t.Run("DuplicatePATHUsesLast", func(t *testing.T) {
+		firstDir := t.TempDir()
+		secondDir := t.TempDir()
+		binPath := filepath.Join(secondDir, "mytool")
+		if err := os.WriteFile(binPath, []byte("#!/bin/sh"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		env := []string{pathEnvKeyForTest() + "=" + firstDir, "PATH=" + secondDir}
+		got := pkrun.LookPathInEnv("mytool", env)
+		if got != binPath {
+			t.Errorf("expected %q, got %q", binPath, got)
+		}
+	})
+
 	t.Run("NotFound", func(t *testing.T) {
 		env := []string{"PATH=/nonexistent"}
 		got := pkrun.LookPathInEnv("nosuchbin", env)

--- a/pk/exec_test.go
+++ b/pk/exec_test.go
@@ -3,7 +3,9 @@ package pk
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/fredrikaverpil/pocket/pk/repopath"
@@ -162,7 +164,7 @@ func TestLookPathInEnv(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		env := []string{"PATH=" + tmpDir}
+		env := []string{pathEnvKeyForTest() + "=" + tmpDir}
 		got := pkrun.LookPathInEnv("mytool", env)
 		if got != binPath {
 			t.Errorf("expected %q, got %q", binPath, got)
@@ -191,22 +193,56 @@ func TestPrependBinToPath(t *testing.T) {
 	repopath.SetGitRootFunc(func() string { return "/repo" })
 	defer repopath.SetGitRootFunc(nil)
 
-	environ := []string{"HOME=/home/user", "PATH=/usr/bin:/usr/local/bin"}
+	environ := []string{"HOME=/home/user", pathEnvKeyForTest() + "=/usr/bin:/usr/local/bin"}
 	got := pkrun.PrependBinToPath(environ)
 
-	var pathValue string
-	for _, e := range got {
-		if len(e) > 5 && e[:5] == "PATH=" {
-			pathValue = e[5:]
-			break
-		}
+	pathValue, ok := pathValueFromEnvForTest(got)
+	if !ok {
+		t.Fatal("PATH not found in result")
 	}
 
 	binDir := filepath.Join("/repo", ".pocket", "bin")
-	if pathValue == "" {
-		t.Fatal("PATH not found in result")
-	}
-	if pathValue[:len(binDir)] != binDir {
+	if !strings.HasPrefix(pathValue, binDir) {
 		t.Errorf("expected PATH to start with %q, got %q", binDir, pathValue)
 	}
+}
+
+func TestPrependBinToPath_AddsPathWhenMissing(t *testing.T) {
+	repopath.SetGitRootFunc(func() string { return "/repo" })
+	defer repopath.SetGitRootFunc(nil)
+
+	got := pkrun.PrependBinToPath([]string{"HOME=/home/user"})
+
+	pathValue, ok := pathValueFromEnvForTest(got)
+	if !ok {
+		t.Fatal("PATH not found in result")
+	}
+
+	want := filepath.Join("/repo", ".pocket", "bin")
+	if pathValue != want {
+		t.Errorf("expected PATH %q, got %q", want, pathValue)
+	}
+}
+
+func pathEnvKeyForTest() string {
+	if runtime.GOOS == "windows" {
+		return "Path"
+	}
+	return "PATH"
+}
+
+func pathValueFromEnvForTest(environ []string) (string, bool) {
+	for _, envEntry := range environ {
+		key, value, ok := strings.Cut(envEntry, "=")
+		if !ok {
+			continue
+		}
+		if runtime.GOOS == "windows" && strings.EqualFold(key, "PATH") {
+			return value, true
+		}
+		if key == "PATH" {
+			return value, true
+		}
+	}
+	return "", false
 }

--- a/pk/run/exec.go
+++ b/pk/run/exec.go
@@ -224,7 +224,6 @@ func LookPathInEnv(name string, env []string) string {
 		key, value, found := strings.Cut(envEntry, "=")
 		if found && isPathEnvKey(key) {
 			pathEnv = value
-			break
 		}
 	}
 

--- a/pk/run/exec.go
+++ b/pk/run/exec.go
@@ -155,7 +155,10 @@ func PrependBinToPath(environ []string) []string {
 	for _, envEntry := range environ {
 		key, path, found := strings.Cut(envEntry, "=")
 		if found && isPathEnvKey(key) {
-			result = append(result, key+"="+prependPathValue(prefix, path))
+			if path != "" {
+				path = string(filepath.ListSeparator) + path
+			}
+			result = append(result, key+"="+prefix+path)
 			foundPath = true
 			continue
 		}
@@ -165,14 +168,6 @@ func PrependBinToPath(environ []string) []string {
 		result = append(result, "PATH="+prefix)
 	}
 	return result
-}
-
-// prependPathValue prepends prefix to an existing PATH value.
-func prependPathValue(prefix, path string) string {
-	if path == "" {
-		return prefix
-	}
-	return fmt.Sprintf("%s%c%s", prefix, filepath.ListSeparator, path)
 }
 
 // isPathEnvKey reports whether key names the process PATH variable.

--- a/pk/run/exec.go
+++ b/pk/run/exec.go
@@ -150,15 +150,37 @@ func PrependBinToPath(environ []string) []string {
 
 	prefix := strings.Join(dirs, string(filepath.ListSeparator))
 
-	result := make([]string, 0, len(environ))
-	for _, env := range environ {
-		if path, found := strings.CutPrefix(env, "PATH="); found {
-			result = append(result, fmt.Sprintf("PATH=%s%c%s", prefix, filepath.ListSeparator, path))
-		} else {
-			result = append(result, env)
+	result := make([]string, 0, len(environ)+1)
+	foundPath := false
+	for _, envEntry := range environ {
+		key, path, found := strings.Cut(envEntry, "=")
+		if found && isPathEnvKey(key) {
+			result = append(result, key+"="+prependPathValue(prefix, path))
+			foundPath = true
+			continue
 		}
+		result = append(result, envEntry)
+	}
+	if !foundPath {
+		result = append(result, "PATH="+prefix)
 	}
 	return result
+}
+
+// prependPathValue prepends prefix to an existing PATH value.
+func prependPathValue(prefix, path string) string {
+	if path == "" {
+		return prefix
+	}
+	return fmt.Sprintf("%s%c%s", prefix, filepath.ListSeparator, path)
+}
+
+// isPathEnvKey reports whether key names the process PATH variable.
+func isPathEnvKey(key string) bool {
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(key, "PATH")
+	}
+	return key == "PATH"
 }
 
 // ApplyEnvConfig applies environment variable overrides from the config.
@@ -203,9 +225,10 @@ func LookPathInEnv(name string, env []string) string {
 	}
 
 	var pathEnv string
-	for _, e := range env {
-		if path, found := strings.CutPrefix(e, "PATH="); found {
-			pathEnv = path
+	for _, envEntry := range env {
+		key, value, found := strings.Cut(envEntry, "=")
+		if found && isPathEnvKey(key) {
+			pathEnv = value
 			break
 		}
 	}


### PR DESCRIPTION
## Why?

- Windows environments commonly spell PATH as `Path`.
- Pocket only matched literal `PATH=`, so `.pocket/bin` could be skipped and command lookup could miss project tools.

```go
[]string{"Path=C:\\Windows\\System32"} // previously ignored on Windows
```

## What?

- Match PATH case-insensitively on Windows while preserving exact matching on Unix.
- Preserve the existing environment key casing when prepending.
- Add `PATH=.pocket/bin` when no PATH entry exists.
- Add regression coverage for PATH lookup and missing-PATH behavior.
- Simplify PATH prepending and test assertions after review.
- Match Go exec environment semantics by using the last duplicate PATH entry.

## Notes

- Tested with `go test ./...`.

