### PR TITLE
fix(pk): report scoped no-ops and missing git root

### DIFF
--- a/pk/builtins.go
+++ b/pk/builtins.go
@@ -53,7 +53,10 @@ var shimsTask = &Task{
 	Usage:      "regenerate shims in all directories",
 	HideHeader: true,
 	Do: func(ctx context.Context) error {
-		gitRoot := repopath.GitRoot()
+		gitRoot, err := repopath.GitRoot()
+		if err != nil {
+			return fmt.Errorf("finding git root: %w", err)
+		}
 		pocketDir := filepath.Join(gitRoot, ".pocket")
 
 		p := planFromContext(ctx)
@@ -169,8 +172,13 @@ var commitsCheckTask = &Task{
 			return nil
 		}
 
+		gitRoot, err := repopath.GitRoot()
+		if err != nil {
+			return fmt.Errorf("finding git root: %w", err)
+		}
+
 		cmd := exec.CommandContext(ctx, "git", "log", "--format=%H %s", commitRange)
-		cmd.Dir = repopath.GitRoot()
+		cmd.Dir = gitRoot
 		var out bytes.Buffer
 		cmd.Stdout = &out
 		cmd.Stderr = &out
@@ -207,7 +215,10 @@ var commitsCheckTask = &Task{
 
 // resolveCommitRange determines the git log range for commit validation.
 func resolveCommitRange(ctx context.Context) (string, error) {
-	gitRoot := repopath.GitRoot()
+	gitRoot, err := repopath.GitRoot()
+	if err != nil {
+		return "", fmt.Errorf("finding git root: %w", err)
+	}
 
 	cmd := exec.CommandContext(ctx, "git", "log", "--oneline", "@{push}..HEAD")
 	cmd.Dir = gitRoot
@@ -263,7 +274,10 @@ var selfUpdateTask = &Task{
 	Usage: "update Pocket and regenerate scaffolded files",
 	Flags: selfUpdateFlags{},
 	Do: func(ctx context.Context) error {
-		gitRoot := repopath.GitRoot()
+		gitRoot, err := repopath.GitRoot()
+		if err != nil {
+			return fmt.Errorf("finding git root: %w", err)
+		}
 		pocketDir := filepath.Join(gitRoot, ".pocket")
 
 		ctx = pkrun.ContextWithPath(ctx, pocketDir)
@@ -311,7 +325,10 @@ var purgeTask = &Task{
 	Name:  "purge",
 	Usage: "remove .pocket/tools, .pocket/bin, and .pocket/venvs",
 	Do: func(ctx context.Context) error {
-		gitRoot := repopath.GitRoot()
+		gitRoot, err := repopath.GitRoot()
+		if err != nil {
+			return fmt.Errorf("finding git root: %w", err)
+		}
 		pocketDir := filepath.Join(gitRoot, ".pocket")
 
 		dirsToRemove := []string{

--- a/pk/cli.go
+++ b/pk/cli.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"sort"
 	"syscall"
 
@@ -30,13 +31,6 @@ func RunMain(cfg *Config) {
 }
 
 func run(cfg *Config) (*executionTracker, error) {
-	// Ensure tools/go.mod exists to prevent go mod tidy from scanning downloaded tools.
-	gitRoot := repopath.GitRoot()
-	pocketDir := filepath.Join(gitRoot, ".pocket")
-	if err := scaffold.EnsureToolsGomod(pocketDir); err != nil {
-		return nil, fmt.Errorf("ensuring tools/go.mod: %w", err)
-	}
-
 	// Parse command-line flags
 	globalFlags := flag.NewFlagSet("pok", flag.ExitOnError)
 
@@ -73,6 +67,16 @@ func run(cfg *Config) (*executionTracker, error) {
 	if showVersion {
 		pkrun.Printf(ctx, "pocket %s\n", version())
 		return nil, nil
+	}
+
+	// Ensure tools/go.mod exists to prevent go mod tidy from scanning downloaded tools.
+	gitRoot, err := repopath.FindGitRoot()
+	if err != nil {
+		return nil, fmt.Errorf("finding git root: %w", err)
+	}
+	pocketDir := filepath.Join(gitRoot, ".pocket")
+	if err := scaffold.EnsureToolsGomod(pocketDir); err != nil {
+		return nil, fmt.Errorf("ensuring tools/go.mod: %w", err)
 	}
 
 	// Build Plan
@@ -282,6 +286,9 @@ func (inst *taskInstance) execute(ctx context.Context) error {
 
 	// Check TASK_SCOPE environment variable (set by shim).
 	if taskScope := taskScopeFromEnv(); taskScope != "" {
+		if !slices.Contains(paths, taskScope) {
+			return fmt.Errorf("task %q is not scoped to %q (available paths: %v)", inst.name, taskScope, paths)
+		}
 		paths = []string{taskScope}
 	}
 

--- a/pk/cli.go
+++ b/pk/cli.go
@@ -70,7 +70,7 @@ func run(cfg *Config) (*executionTracker, error) {
 	}
 
 	// Ensure tools/go.mod exists to prevent go mod tidy from scanning downloaded tools.
-	gitRoot, err := repopath.FindGitRoot()
+	gitRoot, err := repopath.GitRoot()
 	if err != nil {
 		return nil, fmt.Errorf("finding git root: %w", err)
 	}

--- a/pk/cli_test.go
+++ b/pk/cli_test.go
@@ -2,8 +2,37 @@ package pk
 
 import (
 	"context"
+	"errors"
+	"os"
+	"strings"
 	"testing"
+
+	"github.com/fredrikaverpil/pocket/pk/repopath"
 )
+
+func TestRun_ErrorsOutsideGitRepo(t *testing.T) {
+	withArgs(t, "pok")
+	withWorkingDir(t, t.TempDir())
+	repopath.SetGitRootFunc(nil)
+
+	_, err := run(&Config{})
+	if !errors.Is(err, repopath.ErrGitRootNotFound) {
+		t.Fatalf("expected ErrGitRootNotFound, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "finding git root") {
+		t.Errorf("expected git root context, got %v", err)
+	}
+}
+
+func TestRun_VersionDoesNotRequireGitRepo(t *testing.T) {
+	withArgs(t, "pok", "--version")
+	withWorkingDir(t, t.TempDir())
+	repopath.SetGitRootFunc(nil)
+
+	if _, err := run(&Config{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
 
 func TestFindTask_Builtin(t *testing.T) {
 	// findTask should return builtins even with nil plan.
@@ -104,4 +133,32 @@ func TestFindTaskByName_WithSuffix(t *testing.T) {
 	if instance != nil {
 		t.Error("expected nil for base name without suffix")
 	}
+}
+
+func withArgs(t *testing.T, args ...string) {
+	t.Helper()
+
+	oldArgs := os.Args
+	os.Args = args
+	t.Cleanup(func() {
+		os.Args = oldArgs
+	})
+}
+
+func withWorkingDir(t *testing.T, dir string) {
+	t.Helper()
+
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("change working directory: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldDir); err != nil {
+			t.Fatalf("restore working directory: %v", err)
+		}
+		repopath.SetGitRootFunc(nil)
+	})
 }

--- a/pk/plan.go
+++ b/pk/plan.go
@@ -84,7 +84,7 @@ type pathInfo struct {
 // newPublicPlan creates an execution plan from a Config by walking the
 // filesystem to discover directories, then delegating to newPlan.
 func newPublicPlan(cfg *Config) (*Plan, error) {
-	gitRoot, err := repopath.FindGitRoot()
+	gitRoot, err := repopath.GitRoot()
 	if err != nil {
 		return nil, fmt.Errorf("finding git root: %w", err)
 	}

--- a/pk/plan.go
+++ b/pk/plan.go
@@ -84,7 +84,10 @@ type pathInfo struct {
 // newPublicPlan creates an execution plan from a Config by walking the
 // filesystem to discover directories, then delegating to newPlan.
 func newPublicPlan(cfg *Config) (*Plan, error) {
-	gitRoot := repopath.GitRoot()
+	gitRoot, err := repopath.FindGitRoot()
+	if err != nil {
+		return nil, fmt.Errorf("finding git root: %w", err)
+	}
 
 	// Resolve skip dirs: nil uses defaults, empty slice skips nothing
 	var skipDirs []string

--- a/pk/repopath/repopath.go
+++ b/pk/repopath/repopath.go
@@ -1,55 +1,74 @@
 package repopath
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
 )
 
 var (
+	// ErrGitRootNotFound is returned when no git repository root is found.
+	ErrGitRootNotFound = errors.New("git root not found")
+
 	gitRootOnce  sync.Once
 	gitRootCache string
+	gitRootErr   error
 
 	// findGitRootFunc allows overriding GitRoot for tests.
 	findGitRootFunc func() string
 )
 
-// SetGitRootFunc overrides GitRoot for testing. Pass nil to restore default.
-// This must only be used in tests.
+// SetGitRootFunc overrides GitRoot for testing and clears the cached root.
+// Pass nil to restore default discovery. This must only be used in tests.
 func SetGitRootFunc(fn func() string) {
 	findGitRootFunc = fn
+	gitRootOnce = sync.Once{}
+	gitRootCache = ""
+	gitRootErr = nil
+}
+
+// FindGitRoot walks up from the current directory to find the git repository root.
+// It returns ErrGitRootNotFound when no repository root exists.
+// The result is cached after the first call for performance.
+func FindGitRoot() (string, error) {
+	if findGitRootFunc != nil {
+		return findGitRootFunc(), nil
+	}
+	gitRootOnce.Do(func() {
+		gitRootCache, gitRootErr = doFindGitRoot()
+	})
+	return gitRootCache, gitRootErr
 }
 
 // GitRoot walks up from the current directory to find the git repository root.
 // Returns "." if not in a git repository.
 // The result is cached after the first call for performance.
 func GitRoot() string {
-	if findGitRootFunc != nil {
-		return findGitRootFunc()
+	gitRoot, err := FindGitRoot()
+	if err != nil {
+		return "."
 	}
-	gitRootOnce.Do(func() {
-		gitRootCache = doFindGitRoot()
-	})
-	return gitRootCache
+	return gitRoot
 }
 
 // doFindGitRoot performs the actual git root discovery.
-func doFindGitRoot() string {
+func doFindGitRoot() (string, error) {
 	dir, err := os.Getwd()
 	if err != nil {
-		return "."
+		return "", fmt.Errorf("get working directory: %w", err)
 	}
 
 	for {
 		gitDir := filepath.Join(dir, ".git")
 		if _, err := os.Stat(gitDir); err == nil {
-			return dir
+			return dir, nil
 		}
 
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			// Reached root without finding .git
-			return "."
+			return "", ErrGitRootNotFound
 		}
 		dir = parent
 	}

--- a/pk/repopath/repopath.go
+++ b/pk/repopath/repopath.go
@@ -13,40 +13,44 @@ var (
 	ErrGitRootNotFound = errors.New("git root not found")
 
 	gitRootOnce  sync.Once
-	gitRootCache string
-	gitRootErr   error
+	gitRootCache gitRootResult
 
 	// findGitRootFunc allows overriding GitRoot for tests.
 	findGitRootFunc func() string
 )
+
+// gitRootResult holds the cached outcome of git root discovery.
+type gitRootResult struct {
+	root string
+	err  error
+}
 
 // SetGitRootFunc overrides GitRoot for testing and clears the cached root.
 // Pass nil to restore default discovery. This must only be used in tests.
 func SetGitRootFunc(fn func() string) {
 	findGitRootFunc = fn
 	gitRootOnce = sync.Once{}
-	gitRootCache = ""
-	gitRootErr = nil
+	gitRootCache = gitRootResult{}
 }
 
-// FindGitRoot walks up from the current directory to find the git repository root.
+// GitRoot walks up from the current directory to find the git repository root.
 // It returns ErrGitRootNotFound when no repository root exists.
 // The result is cached after the first call for performance.
-func FindGitRoot() (string, error) {
+func GitRoot() (string, error) {
 	if findGitRootFunc != nil {
 		return findGitRootFunc(), nil
 	}
 	gitRootOnce.Do(func() {
-		gitRootCache, gitRootErr = doFindGitRoot()
+		root, err := doFindGitRoot()
+		gitRootCache = gitRootResult{root: root, err: err}
 	})
-	return gitRootCache, gitRootErr
+	return gitRootCache.root, gitRootCache.err
 }
 
-// GitRoot walks up from the current directory to find the git repository root.
-// Returns "." if not in a git repository.
-// The result is cached after the first call for performance.
-func GitRoot() string {
-	gitRoot, err := FindGitRoot()
+// gitRootOrDot returns the git repository root, falling back to "." when no
+// repository root exists.
+func gitRootOrDot() string {
+	gitRoot, err := GitRoot()
 	if err != nil {
 		return "."
 	}
@@ -85,7 +89,7 @@ func doFindGitRoot() (string, error) {
 //	FromGitRoot("pkg")                 → "/path/to/repo/pkg"
 //	FromGitRoot(".")                   → "/path/to/repo"
 func FromGitRoot(paths ...string) string {
-	gitRoot := GitRoot()
+	gitRoot := gitRootOrDot()
 	parts := append([]string{gitRoot}, paths...)
 	return filepath.Join(parts...)
 }
@@ -96,7 +100,7 @@ func FromGitRoot(paths ...string) string {
 //	FromPocketDir("bin")      → "/path/to/repo/.pocket/bin"
 //	FromPocketDir("tools")    → "/path/to/repo/.pocket/tools"
 func FromPocketDir(elem ...string) string {
-	parts := append([]string{GitRoot(), ".pocket"}, elem...)
+	parts := append([]string{gitRootOrDot(), ".pocket"}, elem...)
 	return filepath.Join(parts...)
 }
 

--- a/pk/repopath/repopath_test.go
+++ b/pk/repopath/repopath_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestFindGitRoot(t *testing.T) {
+func TestGitRoot(t *testing.T) {
 	root := t.TempDir()
 	if err := os.Mkdir(filepath.Join(root, ".git"), 0o755); err != nil {
 		t.Fatal(err)
@@ -25,7 +25,7 @@ func TestFindGitRoot(t *testing.T) {
 		t.Fatalf("evaluate root symlinks: %v", err)
 	}
 
-	got, err := FindGitRoot()
+	got, err := GitRoot()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -34,11 +34,11 @@ func TestFindGitRoot(t *testing.T) {
 	}
 }
 
-func TestFindGitRoot_NotFound(t *testing.T) {
+func TestGitRoot_NotFound(t *testing.T) {
 	chdir(t, t.TempDir())
 	SetGitRootFunc(nil)
 
-	got, err := FindGitRoot()
+	got, err := GitRoot()
 	if !errors.Is(err, ErrGitRootNotFound) {
 		t.Fatalf("expected ErrGitRootNotFound, got %v", err)
 	}
@@ -47,12 +47,12 @@ func TestFindGitRoot_NotFound(t *testing.T) {
 	}
 }
 
-func TestGitRoot_NotFoundFallback(t *testing.T) {
+func TestFromGitRoot_NotFoundFallback(t *testing.T) {
 	chdir(t, t.TempDir())
 	SetGitRootFunc(nil)
 
-	if got := GitRoot(); got != "." {
-		t.Errorf("expected fallback root '.', got %q", got)
+	if got := FromGitRoot("pkg"); got != "pkg" {
+		t.Errorf("expected fallback path %q, got %q", "pkg", got)
 	}
 }
 

--- a/pk/repopath/repopath_test.go
+++ b/pk/repopath/repopath_test.go
@@ -1,0 +1,75 @@
+package repopath
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFindGitRoot(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	nested := filepath.Join(root, "services", "api")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	chdir(t, nested)
+	SetGitRootFunc(nil)
+
+	want, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatalf("evaluate root symlinks: %v", err)
+	}
+
+	got, err := FindGitRoot()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("expected git root %q, got %q", want, got)
+	}
+}
+
+func TestFindGitRoot_NotFound(t *testing.T) {
+	chdir(t, t.TempDir())
+	SetGitRootFunc(nil)
+
+	got, err := FindGitRoot()
+	if !errors.Is(err, ErrGitRootNotFound) {
+		t.Fatalf("expected ErrGitRootNotFound, got %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty root, got %q", got)
+	}
+}
+
+func TestGitRoot_NotFoundFallback(t *testing.T) {
+	chdir(t, t.TempDir())
+	SetGitRootFunc(nil)
+
+	if got := GitRoot(); got != "." {
+		t.Errorf("expected fallback root '.', got %q", got)
+	}
+}
+
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("change working directory: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldDir); err != nil {
+			t.Fatalf("restore working directory: %v", err)
+		}
+		SetGitRootFunc(nil)
+	})
+}

--- a/pk/repopath/repopath_test.go
+++ b/pk/repopath/repopath_test.go
@@ -25,9 +25,17 @@ func TestGitRoot(t *testing.T) {
 		t.Fatalf("evaluate root symlinks: %v", err)
 	}
 
-	got, err := GitRoot()
+	gitRoot, err := GitRoot()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Resolve the discovered root too: on Windows the working directory may
+	// use 8.3 short path names (e.g. RUNNER~1) while EvalSymlinks returns
+	// the long form.
+	got, err := filepath.EvalSymlinks(gitRoot)
+	if err != nil {
+		t.Fatalf("evaluate discovered root symlinks: %v", err)
 	}
 	if got != want {
 		t.Errorf("expected git root %q, got %q", want, got)

--- a/pk/shim_test.go
+++ b/pk/shim_test.go
@@ -3,6 +3,7 @@ package pk
 import (
 	"context"
 	"slices"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -252,7 +253,7 @@ func TestTaskExecution_ScopedToPathContext(t *testing.T) {
 		}
 	})
 
-	// Test 3: TASK_SCOPE="." should behave like root (all paths)
+	// Test 3: TASK_SCOPE="." should behave like root (all paths).
 	t.Run("root context explicit", func(t *testing.T) {
 		runCount.Store(0)
 		executedPaths = nil
@@ -268,6 +269,24 @@ func TestTaskExecution_ScopedToPathContext(t *testing.T) {
 
 		if got := runCount.Load(); got != 2 {
 			t.Errorf("expected 2 executions with TASK_SCOPE=., got %d", got)
+		}
+	})
+
+	t.Run("out of scope errors", func(t *testing.T) {
+		runCount.Store(0)
+		executedPaths = nil
+
+		t.Setenv("TASK_SCOPE", "vendor")
+
+		err := ExecuteTask(context.Background(), "scoped-task", p)
+		if err == nil {
+			t.Fatal("expected error for out-of-scope task invocation")
+		}
+		if !strings.Contains(err.Error(), `task "scoped-task" is not scoped to "vendor"`) {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if got := runCount.Load(); got != 0 {
+			t.Errorf("expected task not to execute, got %d executions", got)
 		}
 	})
 }


### PR DESCRIPTION
## Why?

- Direct invocation from a subdirectory shim could silently run nothing and exit 0.
- Running Pocket outside a git repo silently treated `.` as the repo root.

```bash
TASK_SCOPE=vendor ./pok scoped-task # previously exited 0 without running
./pok                              # outside git repo previously used . as root
```

## What?

- Return an error when `TASK_SCOPE` does not match the invoked task's resolved paths ([cli.go:290](https://github.com/fredrikaverpil/pocket/blob/d2844c470b3c3a5cdd3b7c8da2525d79eb64a09a/pk/cli.go#L290)).
- Make [`repopath.GitRoot()`](https://github.com/fredrikaverpil/pocket/blob/d2844c470b3c3a5cdd3b7c8da2525d79eb64a09a/pk/repopath/repopath.go#L39) return `(string, error)` with [`ErrGitRootNotFound`](https://github.com/fredrikaverpil/pocket/blob/d2844c470b3c3a5cdd3b7c8da2525d79eb64a09a/pk/repopath/repopath.go#L13); CLI plan setup and builtins propagate the error instead of falling back to `.`.
- Keep the `.` fallback only in the unexported [`gitRootOrDot()`](https://github.com/fredrikaverpil/pocket/blob/d2844c470b3c3a5cdd3b7c8da2525d79eb64a09a/pk/repopath/repopath.go#L52) used by the `From*` path helpers, preserving their existing behavior.
- Add regression tests for scoped no-ops, missing git roots, and `--version` outside repos.

## Notes

- `pok --help` outside a git repo now errors (it needs a plan); previously it walked `.` as the repo root.
- Tested with `go test ./...` in CI on macOS, Ubuntu, and Windows.