### PR TITLE
ci: run go mod tidy on renovate branches

### DIFF
--- a/.github/workflows/renovate-tidy.yml
+++ b/.github/workflows/renovate-tidy.yml
@@ -1,0 +1,48 @@
+# Renovate runs `go mod tidy` only in the module whose go.mod it updated
+# (postUpdateOptions: gomodTidy in renovate.json). The .pocket module dogfoods
+# pocket via a `replace => ../` directive, so root go.mod bumps leave
+# .pocket/go.mod and .pocket/go.sum stale and CI fails with "updates to
+# go.mod needed". This workflow tidies both modules on Renovate branches and
+# pushes a fixup commit when they drift.
+
+name: renovate-tidy
+
+on:
+  push:
+    branches:
+      - "renovate/**"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  go-mod-tidy:
+    name: go mod tidy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: .pocket/go.mod
+          cache: false
+      - name: Run go mod tidy
+        run: |
+          go mod tidy
+          cd .pocket
+          go mod tidy
+      - name: Commit and push changes
+        run: |
+          if git diff --quiet; then
+            echo "go.mod/go.sum files are tidy, nothing to do"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add go.mod go.sum .pocket/go.mod .pocket/go.sum
+          git commit -m "chore: run go mod tidy"
+          git push


### PR DESCRIPTION
## Why

PR #101 (and Go dependency bumps in general) leave the repo in a state where `go mod tidy` must be run manually:

- `renovate.json` already has `"postUpdateOptions": ["gomodTidy"]`, but Renovate only tidies the module whose `go.mod` it updated (the repo root).
- `.pocket/go.mod` dogfoods pocket via `replace github.com/fredrikaverpil/pocket => ../`, so root dependency bumps change `.pocket`'s build list too. Its `go.mod`/`go.sum` go stale, and CI then fails with `go: updates to go.mod needed; to update it: go mod tidy`.

Renovate's hosted app cannot be configured to tidy modules it didn't touch (`postUpgradeTasks` requires a self-hosted runner), so this takes the CI route instead.

## What

Adds `.github/workflows/renovate-tidy.yml`, which on every push to a `renovate/**` branch:

1. Runs `go mod tidy` at the repo root and in `.pocket/`.
2. If that produces a diff, commits it as `chore: run go mod tidy` and pushes to the Renovate branch.

The workflow is hand-written but safe: the `github-workflows` task only manages its own fixed set of filenames and leaves this file alone (verified locally with `./pok -c github-workflows`).

## Known caveat

Commits pushed with the workflow's `GITHUB_TOKEN` do not trigger new workflow runs, so after the tidy commit lands, the PR's checks won't re-run automatically. Close/reopen the PR (or push any commit) to retrigger. If that turns out to be annoying, options are a PAT/bot token or having the workflow close+reopen the PR itself.

🤖 Generated with [Kimi Code](https://github.com/anthropics/kimi-code)