### PR TITLE
fix(markdown): always write bundled rumdl config so projects can extend it

### DIFF
--- a/tasks/markdown/format.go
+++ b/tasks/markdown/format.go
@@ -35,11 +35,13 @@ func formatCmd() pk.Runnable {
 			args = append(args, "--verbose")
 		}
 
-		// Fall back to the bundled config when the project has no rumdl
-		// config of its own.
+		// Always write the bundled config so a project config can inherit
+		// from it via rumdl's `extends`, then fall back to it only when the
+		// project has no rumdl config of its own.
+		defaultConfig := rumdl.EnsureDefaultConfig()
 		configPath := f.Config
 		if configPath == "" && !rumdl.HasProjectConfig() {
-			configPath = rumdl.EnsureDefaultConfig()
+			configPath = defaultConfig
 		}
 		if configPath != "" {
 			args = append(args, "--config", configPath)

--- a/tools/rumdl/rumdl.go
+++ b/tools/rumdl/rumdl.go
@@ -38,6 +38,11 @@ var configFileNames = []string{
 // EnsureDefaultConfig writes the bundled config to .pocket/tools/rumdl/
 // and returns its path. The file is rewritten on every call so it stays in
 // sync with the embedded config. Safe to call multiple times.
+//
+// It is written whether or not the project has a config of its own, so that a
+// project config can inherit these defaults with rumdl's `extends`:
+//
+//	extends = ".pocket/tools/rumdl/rumdl.toml"
 func EnsureDefaultConfig() string {
 	configPath := repopath.FromToolsDir("rumdl", DefaultConfigFile)
 	_ = os.MkdirAll(filepath.Dir(configPath), 0o755)

--- a/tools/rumdl/rumdl.toml
+++ b/tools/rumdl/rumdl.toml
@@ -1,5 +1,13 @@
 # Default rumdl configuration.
 # Used when the project has no rumdl config of its own at the git root.
+#
+# To keep these defaults while adding project-specific settings, inherit from
+# this file in a rumdl.toml at the git root:
+#
+#   extends = ".pocket/tools/rumdl/rumdl.toml"
+#
+#   [per-file-flavor]
+#   "docs/**/*.md" = "mkdocs"  # MkDocs/zensical admonitions, content tabs, ...
 
 [global]
 # MD034: leave bare URLs/emails untouched (no <...> wrapping).


### PR DESCRIPTION
## Why?

- [rumdl](https://github.com/rvben/rumdl)'s [`extends`](https://github.com/rvben/rumdl/blob/master/docs/global-settings.md#extends) was unusable from Pocket. The bundled config was only written when the project had *no* rumdl config of its own, so adding a `rumdl.toml` to set one key removed the very file it wanted to inherit from:

  ```
  Config error: extends target not found: .pocket/tools/rumdl/rumdl.toml
  (referenced from rumdl.toml)
  ```

- Projects were therefore forced to copy the whole bundled config to change anything, and those copies then drift from Pocket's defaults on every upgrade.
- Concretely, this blocks repos that mix GitHub READMEs with [MkDocs](https://www.mkdocs.org/)/[zensical](https://zensical.org/) docs. Under rumdl's default `standard` flavor an indented `!!! note` body parses as an indented code block, and [MD046](https://github.com/rvben/rumdl/blob/master/docs/md046.md) rewrites it into a fenced one — destroying the admonition:

  ````diff
   !!! note "Note on `go.mod`"

  -    All the above commands must be run somewhere beneath the location of
  -    the `go.mod` file specifying the _module_ name.
  +```
  +All the above commands must be run somewhere beneath the location of
  +the `go.mod` file specifying the _module_ name.
  +```
  ````

  (real case: [neotest-golang#596](https://github.com/fredrikaverpil/neotest-golang/pull/596#discussion_r3724987658))

## What?

- [tasks/markdown/format.go:44](https://github.com/fredrikaverpil/pocket/blob/bf6b06fa40f8afd1bd86b4665ff194e4de7b67cf/tasks/markdown/format.go#L44) — call `rumdl.EnsureDefaultConfig()` unconditionally; still pass it as `--config` only when the project has no config of its own, so the default path is unchanged.
- [tools/rumdl/rumdl.go:38](https://github.com/fredrikaverpil/pocket/blob/bf6b06fa40f8afd1bd86b4665ff194e4de7b67cf/tools/rumdl/rumdl.go#L38) — godoc records why it is written unconditionally.
- [tools/rumdl/rumdl.toml](https://github.com/fredrikaverpil/pocket/blob/bf6b06fa40f8afd1bd86b4665ff194e4de7b67cf/tools/rumdl/rumdl.toml) — document the recipe where users will actually look:

  ```toml
  extends = ".pocket/tools/rumdl/rumdl.toml"

  [per-file-flavor]
  "docs/**/*.md" = "mkdocs"
  ```

- Flavor is a property of a directory, not of a repo, so [`per-file-flavor`](https://github.com/rvben/rumdl/blob/master/docs/global-settings.md#per-file-flavor) is the right fix rather than a repo-wide flavor setting — READMEs stay GFM-strict while `docs/**` gets MkDocs parsing. This is what rumdl itself does in [its own `.rumdl.toml`](https://github.com/rvben/rumdl/blob/master/.rumdl.toml).

## Notes

- Verified by running `md-format` via `./pok` in a scratch repo against the real `docs/contrib.md` from neotest-golang `main`:
  - admonition survives; README's bare URL still untouched (bundled `MD034` disable inherited through `extends`)
  - `exclude = ["/CHANGELOG.md"]` is also inherited, so release-please changelogs stay protected under the new pattern
  - control: with the bundled file absent (old behaviour) rumdl hard-fails as above
  - regression: with no project config, bundled defaults apply exactly as before
- Adjacent gap, not addressed here: `rumdl.HasProjectConfig()` does not check `pyproject.toml` with a `[tool.rumdl]` section, which rumdl also supports. Such a project still gets Pocket's `--config` forced over it. Pre-existing.
