### PR TITLE
fix(renovate): validate renovate.json as repo config

### DIFF
--- a/tasks/renovate/validate.go
+++ b/tasks/renovate/validate.go
@@ -22,8 +22,10 @@ func validateCmd() pk.Runnable {
 			"x",
 			"--package",
 			"renovate",
+			// No file argument: explicitly passed files are validated as
+			// global config, while auto-discovery validates them as repo
+			// config, which is how Renovate actually reads them.
 			"renovate-config-validator",
-			"renovate.json",
 		)
 	})
 }


### PR DESCRIPTION
## Why?

- [`renovate-config-validator`](https://docs.renovatebot.com/config-validation/) validates explicitly passed files as **global** config, but Renovate reads `renovate.json` as **repo** config.
- The two use different schemas, so we were validating the file against rules that do not match how it is actually consumed.

## What?

- Drop the `renovate.json` argument from the `renovate-validate` task and rely on auto-discovery.

```diff
  "renovate-config-validator",
- "renovate.json",
```

## Notes

Output before:

```
INFO: Validating renovate.json as global config
```

After:

```
INFO: Validating renovate.json
```

The unrelated `WARN: RE2 not usable` line still appears — [`re2`](https://github.com/uhop/node-re2)'s native addon is not built under [`bun x`](https://bun.sh/docs/cli/bunx), so Renovate falls back to JS `RegExp`. It also trips Pocket's notice-pattern detection, which is why the run reports "completed with warnings".